### PR TITLE
Switch from Git SSH to HTTPS source URL so we can publish the pod file

### DIFF
--- a/Astro.podspec
+++ b/Astro.podspec
@@ -28,7 +28,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
     "Dominic Pepin" => "Dominic.Pepin@RobotsAndPencils.com", 
     "Michael Beaureguard" => "Michael.Beauregard@RobotsAndPencils.com" 
   }
-  s.source           = { :git => "git@github.com:RobotsAndPencils/Astro.git", :tag => s.version.to_s }
+  s.source           = { :git => "https://github.com/RobotsAndPencils/Astro.git", :tag => s.version.to_s }
 
   s.ios.deployment_target = '8.0'
   s.platform     = :ios, '8.0'


### PR DESCRIPTION
Simple change to allow us to publish the Astro repository publicly in CocoaPods. To test just run the `pod spec lint Astro.podspec` and/or `pod lib lint Astro.podspec` command to see if it passes...