### PR TITLE
Mass updates for API documentation

### DIFF
--- a/Astro/Logging/Log.swift
+++ b/Astro/Logging/Log.swift
@@ -34,7 +34,7 @@ public struct Log {
      
      - Debug - is good for dumping variable values and runtime details and is typically only turned on for dev builds
      - Info - is good for tracing application flow and is typically only turned on for dev builds
-     - Warning - is good for logging application problems that aren't fatal or user affecting
+     - Warning - is good for logging application problems that aren't fatal or affect users
      - Error - is good for logging application errors that are fatal or impact users
      - Silent - allows you to shut off the logger completely with minimal performance impacts
     */

--- a/Astro/Logging/Log.swift
+++ b/Astro/Logging/Log.swift
@@ -11,12 +11,33 @@
 
 import Foundation
 
+/**
+ Prototol that allows you to define your own Logger implementations and use them for logging messages.
+ */
 public protocol Logger {
+    /**
+     Log a message with a given log level
+     
+     - Parameter level: Importance level of the message to be logged
+     - Parameter message: Message contents that will be logged
+    */
     func log(level: Log.Level, message: String);
 }
 
+/**
+ Log is a structure that streamlines the printing of log messages and has a basic logger implementation that logs to NSLog.
+ */
 public struct Log {
     
+    /**
+     The available levels that can be logged by the Logger. 
+     
+     - Debug - is good for dumping variable values and runtime details and is typically only turned on for dev builds
+     - Info - is good for tracing application flow and is typically only turned on for dev builds
+     - Warning - is good for logging application problems that aren't fatal or user affecting
+     - Error - is good for logging application errors that are fatal or impact users
+     - Silent - allows you to shut off the logger completely with minimal performance impacts
+    */
     public enum Level: Int {
         case Debug
         case Info
@@ -25,6 +46,9 @@ public struct Log {
         case Silent
     }
     
+    /**
+     A default logger implementation that logs to NSLog with the log message prefixed by its log Level
+    */
     public struct BasicLogger: Logger {
         public func log(level: Level, message: String) {
             var prefix = ""
@@ -49,27 +73,46 @@ public struct Log {
         }
     }
     
+    /**
+     Contains the current logging level that is configured
+     */
     public static var level = Level.Error
+    
+    /**
+     Contains the current logger that is configured
+     */
     public static var logger: Logger = BasicLogger()
     
+    /**
+     Log a debug message
+     */
     public static func debug(@autoclosure msg: () -> String) {
         if level.rawValue <= Level.Debug.rawValue {
             logger.log(.Debug, message: msg())
         }
     }
     
+    /**
+     Log an info message
+     */
     public static func info(@autoclosure msg: () -> String) {
         if level.rawValue <= Level.Info.rawValue {
             logger.log(.Info, message: msg())
         }
     }
     
+    /**
+     Log a warning message
+     */
     public static func warn(@autoclosure msg: () -> String) {
         if level.rawValue <= Level.Warning.rawValue {
             logger.log(.Warning, message: msg())
         }
     }
     
+    /**
+     Log an error message
+     */
     public static func error(@autoclosure msg: () -> String) {
         if level.rawValue <= Level.Error.rawValue {
             logger.log(.Error, message: msg())

--- a/Astro/Networking/HTTPStatusCode.swift
+++ b/Astro/Networking/HTTPStatusCode.swift
@@ -15,6 +15,17 @@
 
 import Foundation
 
+/**
+ HTTPStatusCode is an enum that allows you to clarify status codes returned by your server and includes some more user friendly messaging for failureReason and recoverySuggestion.
+ 
+ Codes are grouped into the following bands:
+ 
+ - Information codes (100-199)
+ - Success codes (200-299)
+ - Redirection codes (300-399)
+ - Client error codes (400-499)
+ - Server error codes (>500)
+ */
 @objc public enum HTTPStatusCode: Int, CustomStringConvertible, CustomDebugStringConvertible {
     // Informational - 1xx codes
     case Code100Continue = 100
@@ -76,10 +87,16 @@ import Foundation
 
     // MARK: CustomDebugStringConvertible
 
+    /**
+     - Returns: a detailed string representation (code + string) of this HTTPStatusCode
+     */
     public var debugDescription: String {
         return "HTTPStatusCode: \(rawValue) - \(string)"
     }
 
+    /**
+     - Returns: a string representation of the HTTPStatusCode
+     */
     public var string: String {
         switch self {
         case .Code100Continue: return "Continue"
@@ -128,6 +145,9 @@ import Foundation
 
     // MARK: Lifecycle
 
+    /**
+     Initializer that takes a raw HTTP Status Code and creates a HTTPStatusCode representation. Will return nil if the code is not known.
+     */
     public init?(intValue: Int) {
         guard let statusCode = HTTPStatusCode(rawValue: intValue) else {
             return nil
@@ -138,32 +158,53 @@ import Foundation
 
     // MARK: Public
 
+    /**
+     - Returns: true if the HTTPStatusCode is in the range of 100-199
+     */
     public var isInformational: Bool {
         return rawValue >= 100 && rawValue < 200
     }
 
+    /**
+     - Returns: true if the HTTPStatusCode is in the range of 200-299
+     */
     public var isSuccessful: Bool {
         return rawValue >= 200 && rawValue < 300
     }
 
+    /**
+     - Returns: true if the HTTPStatusCode is in the range of 300-399
+     */
     public var isRedirection: Bool {
         return rawValue >= 300 && rawValue < 400
     }
 
+    /**
+     - Returns: true if the HTTPStatusCode is in the range of 400-499
+     */
     public var isClientError: Bool {
         return rawValue >= 400 && rawValue < 500
     }
 
+    /**
+     - Returns: true if the HTTPStatusCode is in the range of >=500
+     */
     public var isServerError: Bool {
         return rawValue >= 500
     }
 
+    /**
+     - Returns: true if the HTTPStatusCode is either a Server of Client error (i.e. >= 400)
+     */
     public var isError: Bool {
         return isServerError || isClientError
     }
 }
 
 extension HTTPStatusCode {
+    /**
+     - Returns: a more detailed failure reason for this HTTPStatusCode error condition
+     */
     public var failureReason: String {
         if !self.isError { return "" }
 
@@ -201,6 +242,9 @@ extension HTTPStatusCode {
         }
     }
 
+    /**
+     - Returns: a suggestion on how you might recover from this HTTPStatusCode error condition
+     */
     public var recoverySuggestion: String {
         if !self.isError { return "" }
 

--- a/Astro/Networking/Route.swift
+++ b/Astro/Networking/Route.swift
@@ -12,6 +12,9 @@
 import Alamofire
 import Freddy
 
+/**
+ Route provides a simple abstraction for working with NSURLRequests. Recommended approach is to add extensions to Route to add a default baseURL value and static functions for your specific API.
+ */
 public struct Route: URLRequestConvertible {
     public let baseURL: NSURL
     public let path: String
@@ -91,6 +94,11 @@ public enum RequestParameters {
     }
 }
 
+/**
+ Allows a String to be base64 encoded so you can safely transport it across the network
+ 
+ - Returns: A new string that has been base64 encoded
+ */
 public extension String {
     public func base64Encode() -> String {
         let data = self.dataUsingEncoding(NSUTF8StringEncoding)

--- a/Astro/Security/KeychainAccess.swift
+++ b/Astro/Security/KeychainAccess.swift
@@ -23,10 +23,18 @@ let KeychainAccessServiceBundleID: String = {
 
 let KeychainAccessErrorDomain = "\(KeychainAccessServiceBundleID).error"
 
+/**
+ KeychainAccess provides the app access to a device's Keychain store. Usage is fairly straightforward, as part of an account, you can place strings (or data) for a key into the Keychain and then recover those values later. This makes it a good way to securely store a specific user's password or tokens for reuse in the app.
+ */
 public class KeychainAccess {
     
     let keychainAccessAccount: String?
     
+    /**
+     Initialize a new instance of KeychainAccess given a unique account identifier
+     
+     - parameter account: the account for which the keys will be appended in the keychain
+     */
     public init(account: String) {
         keychainAccessAccount = account
     }
@@ -147,7 +155,7 @@ public class KeychainAccess {
     }
 
     /**
-       Delete the all keys and data for the app.
+       Delete all keys and data for the app.
      
        - returns: true if the delete was successful, false if there was an error
      */

--- a/Astro/Security/KeychainAccess.swift
+++ b/Astro/Security/KeychainAccess.swift
@@ -24,7 +24,7 @@ let KeychainAccessServiceBundleID: String = {
 let KeychainAccessErrorDomain = "\(KeychainAccessServiceBundleID).error"
 
 /**
- KeychainAccess provides the app access to a device's Keychain store. Usage is fairly straightforward, as part of an account, you can place strings (or data) for a key into the Keychain and then recover those values later. This makes it a good way to securely store a specific user's password or tokens for reuse in the app.
+ KeychainAccess provides the app access to a device's Keychain store. Usage is fairly straightforward, as part of an account, you can place strings (or data) for a key into the Keychain and then retrieve those values later. This makes it a good way to securely store a specific user's password or tokens for reuse in the app.
  */
 public class KeychainAccess {
     

--- a/Astro/UI/LayoutLabel.swift
+++ b/Astro/UI/LayoutLabel.swift
@@ -15,6 +15,7 @@ import UIKit
  LayoutLabel implements some logic to ensure that a UILabel properly resizes itself based on its content.
  Used in situations like determining cell height in a UITableView, ensuring that labels fit their content
  after a constraint change, etc...
+ 
  Based on http://stackoverflow.com/questions/18118021/how-to-resize-superview-to-fit-all-subviews-with-autolayout
  */
 public class LayoutLabel: UILabel {

--- a/Astro/UI/NibLoadableView.swift
+++ b/Astro/UI/NibLoadableView.swift
@@ -12,15 +12,13 @@
 import UIKit
 
 /**
- NibLoadableView is a way to generalize the pattern of declaring a constant for
- every nib file. Much of this is based off of the ideas from:
- https://medium.com/@gonzalezreal/ios-cell-registration-reusing-with-swift-protocol-extensions-and-generics-c5ac4fb5b75e
- */
-
-/**
  A protocol for views having a corresponding nib to expose a default name, but
  can easily be overridden if the corresponding nib filename is different from
  that of its class
+
+ NibLoadableView is a way to generalize the pattern of declaring a constant for
+ every nib file. Much of this is based off of the ideas from:
+ https://medium.com/@gonzalezreal/ios-cell-registration-reusing-with-swift-protocol-extensions-and-generics-c5ac4fb5b75e
  */
 public protocol NibLoadableView: class {
     static var nibName: String { get }

--- a/Astro/UI/ReusableView.swift
+++ b/Astro/UI/ReusableView.swift
@@ -12,13 +12,11 @@
 import UIKit
 
 /**
+ A protocol for reusable-type views to provide a default reuse identifier
+
  ReusableView is a way to generalize the pattern of declaring a constant for
  every reuse identifier. Much of this is based off of the ideas from:
  https://medium.com/@gonzalezreal/ios-cell-registration-reusing-with-swift-protocol-extensions-and-generics-c5ac4fb5b75e
- */
-
-/**
- A protocol for reusable-type views to provide a default reuse identifier 
  */
 public protocol ReusableView: class {
     static var defaultReuseIdentifier: String { get }

--- a/Astro/UI/UIColor+AstroGadgets.swift
+++ b/Astro/UI/UIColor+AstroGadgets.swift
@@ -11,6 +11,9 @@
 
 import UIKit
 
+/**
+ Includes a UIColor extension for hex code (e.g. #FF0000) support. You can now create your project's color palette in another class extension that brings all those pesky colors into one place and with names that are easy to understand:
+ */
 extension UIColor {
     /**
        Create a color from a string of hexadecimal characters.

--- a/Astro/UI/UIView+AstroGadgets.swift
+++ b/Astro/UI/UIView+AstroGadgets.swift
@@ -11,9 +11,10 @@
 
 import UIKit
 
+/**
+ Shortcuts for getting and setting the frame properties
+ */
 public extension UIView {
-    
-    // MARK: Shortcuts for getting and setting the frame properties
     
     public var frameSize:CGSize {
         get {

--- a/Astro/UI/UIViewController+AstroGadgets.swift
+++ b/Astro/UI/UIViewController+AstroGadgets.swift
@@ -11,12 +11,18 @@
 
 import UIKit
 
+/**
+ Extensions to help deliver additional UIViewController functionality
+ */
 public extension UIViewController {
     
     // MARK: General
     
     /**
-       Ensure that a view controller is added properly to another view controller
+     Ensure that a view controller is added properly to another view controller
+     
+     - parameter childViewController: to be added inside of the parent view controller (i.e. self)
+     - parameter inContainer: the UIView where the childViewController's UIView will be added as a subview
     */
     public func addChildViewController(childViewController: UIViewController, inContainer view: UIView) {
         self.addChildViewController(childViewController)
@@ -31,8 +37,11 @@ public extension UIViewController {
     // MARK: Alerts
     
     /**
-       Shorten way to prompt an alert
-    */
+     A quick way to show an alert with a single Ok button
+     
+     - parameter title: - of the alert
+     - parameter message: - of the alert
+     */
     public func quickAlert(title title: String?, message: String?) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: UIAlertControllerStyle.Alert)
         alert.addAction(UIAlertAction(title: "OK", style: UIAlertActionStyle.Default, handler: nil))
@@ -40,7 +49,7 @@ public extension UIViewController {
     }
     
     /**
-       Prompts an alert indicating that the feature has not been implemented
+     Show an alert indicating that the feature has not been implemented. Useful when developing new features and you quickly want to stub out an unfinished areas.
     */
     public func featureNotImplemented() {
         NSLog("FEATURE NOT IMPLEMENTED")

--- a/Astro/Utils/EnumCountable.swift
+++ b/Astro/Utils/EnumCountable.swift
@@ -10,14 +10,12 @@
 //
 
 /**
- EnumCountable allows you to add a "count" constant to Swift enums of type Int.
+ EnumCountable provides an easy way to add a static count constant to Swift enums of type Int.
  
- Requirements:
- - The enum must be of type Int
- - The first case must start at 0  
- - All cases must be continous
+ It requires that the first case start at 0 and all cases must be continuous.
  
  Usage:
+ ```
  enum MyEnum: Int, EnumCountable {
     case case1 = 0
     case case2
@@ -25,15 +23,17 @@
  
     static let count = MyEnum.countCases()  // Lazy-initialize the constant 'count' to the number of enum cases
  }
+ ```
  */
-
 public protocol EnumCountable {
     static var count : Int { get }
 }
 
 public extension EnumCountable where Self : RawRepresentable, Self.RawValue == Int {
     
-    // Counts the number of cases in the enum, starting at 0
+    /**
+    Counts the number of cases in the enum, starting at 0
+    */
     static func countCases() -> Int {
         var count = 0
         while let _ = Self(rawValue: count) {

--- a/Astro/Utils/Queue.swift
+++ b/Astro/Utils/Queue.swift
@@ -25,6 +25,9 @@ public extension ExecutableQueue {
     }
 }
 
+/**
+ Queue provides a prettier interface for the most common needs of dispatching onto different GCD Queues. If you require something more powerfull consider Async.
+ */
 public enum Queue: ExecutableQueue {
     case Main
     case UserInteractive


### PR DESCRIPTION
Adding in documentation headers so new developers can explore the API while inside their IDE. This will also boost our coverage rating in the CocoaDocs.org repository once it is released.
http://cocoadocs.org/docsets/Astro/1.0.0/index.html (doc coverage was at 18% on our first release)

## How to test
1. Grab this code base and load it up in Xcode/IDE
2. Option-tap on Astro class/function to see the inline documentation
3. If you have knowledge of the NetworkService, Route or Queue classes and can provide documentation updates that would be outstanding!

## Areas of the app affected
No functional changes