### PR TITLE
Add network request notifications and logging

### DIFF
--- a/Astro.xcodeproj/project.pbxproj
+++ b/Astro.xcodeproj/project.pbxproj
@@ -13,8 +13,11 @@
 		2E93487124A5E044E0199250 /* HTTPStatusCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E934F99FFAF39F046F75750 /* HTTPStatusCode.swift */; };
 		2E934B8A416AF015C76347DC /* UIViewController+AstroGadgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9348D0FB90D68FC7E5C3D7 /* UIViewController+AstroGadgets.swift */; };
 		2E934D1B02F8932284DCF220 /* UIViewController+AstroGadgetsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9348C107F407A4402AB69F /* UIViewController+AstroGadgetsSpec.swift */; };
+		3ED7E0B3E861F8023637D769 /* NetworkRequestLoggerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED7E5AEE115EFAF2A2BD59D /* NetworkRequestLoggerSpec.swift */; };
+		3ED7E5160B9194EFD65AD935 /* SpecHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED7EC64410D69E252806A27 /* SpecHelpers.swift */; };
+		3ED7E70C2A0CC260E6CB6884 /* NetworkServiceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8E16F41CCA801000E0B4DD /* NetworkServiceSpec.swift */; };
+		3ED7EA386EBCBC334F309446 /* NetworkServiceLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED7E67DD474017D8D6536AD /* NetworkServiceLogger.swift */; };
 		3F78B5501CC35D4900A0E30C /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F78B54F1CC35D4900A0E30C /* Queue.swift */; };
-		3F8E16F51CCA801000E0B4DD /* NetworkServiceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8E16F41CCA801000E0B4DD /* NetworkServiceSpec.swift */; };
 		3F8E16FA1CCA843100E0B4DD /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8E16F71CCA843100E0B4DD /* NetworkService.swift */; };
 		3F8E16FB1CCA843100E0B4DD /* Route.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8E16F81CCA843100E0B4DD /* Route.swift */; };
 		3FCD95D71CCC2D3400A5442F /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FCD95D61CCC2D3400A5442F /* User.swift */; };
@@ -31,13 +34,13 @@
 		CA5380CD1C5C196E00204A68 /* UIColor+AstroGadgetsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5380CC1C5C196E00204A68 /* UIColor+AstroGadgetsSpec.swift */; };
 		D0C3176529877E28CFD27E77 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C31A257874127AD224738D /* Log.swift */; };
 		D6F831A48F327D5367262464 /* Pods_AstroTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D24B772E4EC6454D9C2C893 /* Pods_AstroTests.framework */; };
-		F454FB4E1A6FC16378B23DF1 /* Pods_Astro.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 273FFD8472B2BF5BD8B6DF9F /* Pods_Astro.framework */; };
-		E62F9D221D623675005402BF /* ReusableViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62F9D211D623675005402BF /* ReusableViewSpec.swift */; };
 		E62F9D1C1D62264F005402BF /* UICollectionView+AstroGadgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62F9D1B1D62264F005402BF /* UICollectionView+AstroGadgets.swift */; };
 		E62F9D1E1D6227DE005402BF /* UITableView+AstroGadgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62F9D1D1D6227DE005402BF /* UITableView+AstroGadgets.swift */; };
+		E62F9D221D623675005402BF /* ReusableViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62F9D211D623675005402BF /* ReusableViewSpec.swift */; };
 		E665B02B1D35BB4B0099C89E /* NibLoadableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E665B02A1D35BB4B0099C89E /* NibLoadableView.swift */; };
 		E6D5F8841D35B55600CB4D5F /* ReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D5F8831D35B55600CB4D5F /* ReusableView.swift */; };
 		E6F32EE51D6264FE00D31F64 /* NibLoadableViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F32EE41D6264FE00D31F64 /* NibLoadableViewSpec.swift */; };
+		F454FB4E1A6FC16378B23DF1 /* Pods_Astro.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 273FFD8472B2BF5BD8B6DF9F /* Pods_Astro.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,6 +63,9 @@
 		2E9348D0FB90D68FC7E5C3D7 /* UIViewController+AstroGadgets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+AstroGadgets.swift"; sourceTree = "<group>"; };
 		2E934B3DCE343BE7D9CECCCD /* HTTPStatusCodeSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPStatusCodeSpec.swift; sourceTree = "<group>"; };
 		2E934F99FFAF39F046F75750 /* HTTPStatusCode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPStatusCode.swift; sourceTree = "<group>"; };
+		3ED7E5AEE115EFAF2A2BD59D /* NetworkRequestLoggerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkRequestLoggerSpec.swift; sourceTree = "<group>"; };
+		3ED7E67DD474017D8D6536AD /* NetworkServiceLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkServiceLogger.swift; sourceTree = "<group>"; };
+		3ED7EC64410D69E252806A27 /* SpecHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpecHelpers.swift; sourceTree = "<group>"; };
 		3F78B54F1CC35D4900A0E30C /* Queue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Queue.swift; path = Utils/Queue.swift; sourceTree = "<group>"; };
 		3F8E16F41CCA801000E0B4DD /* NetworkServiceSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkServiceSpec.swift; sourceTree = "<group>"; };
 		3F8E16F71CCA843100E0B4DD /* NetworkService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
@@ -83,13 +89,12 @@
 		CA5380CC1C5C196E00204A68 /* UIColor+AstroGadgetsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+AstroGadgetsSpec.swift"; sourceTree = "<group>"; };
 		D0C31A257874127AD224738D /* Log.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
 		D5D8E2A7279FA75989658B29 /* Pods-Astro.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Astro.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Astro/Pods-Astro.debug.xcconfig"; sourceTree = "<group>"; };
-		E62F9D211D623675005402BF /* ReusableViewSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReusableViewSpec.swift; sourceTree = "<group>"; };
 		E62F9D1B1D62264F005402BF /* UICollectionView+AstroGadgets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UICollectionView+AstroGadgets.swift"; sourceTree = "<group>"; };
 		E62F9D1D1D6227DE005402BF /* UITableView+AstroGadgets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITableView+AstroGadgets.swift"; sourceTree = "<group>"; };
+		E62F9D211D623675005402BF /* ReusableViewSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReusableViewSpec.swift; sourceTree = "<group>"; };
 		E665B02A1D35BB4B0099C89E /* NibLoadableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NibLoadableView.swift; sourceTree = "<group>"; };
 		E6D5F8831D35B55600CB4D5F /* ReusableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReusableView.swift; sourceTree = "<group>"; };
 		E6F32EE41D6264FE00D31F64 /* NibLoadableViewSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NibLoadableViewSpec.swift; sourceTree = "<group>"; };
-		FB15C2DB1FFCE31DEC4C7201 /* Pods-AstroTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AstroTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AstroTests/Pods-AstroTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -118,6 +123,7 @@
 			children = (
 				2E934B3DCE343BE7D9CECCCD /* HTTPStatusCodeSpec.swift */,
 				3F8E16F41CCA801000E0B4DD /* NetworkServiceSpec.swift */,
+				3ED7E5AEE115EFAF2A2BD59D /* NetworkRequestLoggerSpec.swift */,
 				3FCD95D61CCC2D3400A5442F /* User.swift */,
 			);
 			path = Networking;
@@ -159,6 +165,7 @@
 				63379D771C06394900DDD95B /* Security */,
 				2E934BF4A4C69C31C5403859 /* UI */,
 				BD62EA491C929C04004A02DF /* Utils */,
+				3ED7EC64410D69E252806A27 /* SpecHelpers.swift */,
 			);
 			path = "Unit Tests";
 			sourceTree = "<group>";
@@ -168,6 +175,7 @@
 			children = (
 				2E934F99FFAF39F046F75750 /* HTTPStatusCode.swift */,
 				3F8E16F71CCA843100E0B4DD /* NetworkService.swift */,
+				3ED7E67DD474017D8D6536AD /* NetworkServiceLogger.swift */,
 				3F8E16F81CCA843100E0B4DD /* Route.swift */,
 			);
 			path = Networking;
@@ -499,6 +507,7 @@
 				3F78B5501CC35D4900A0E30C /* Queue.swift in Sources */,
 				3F8E16FB1CCA843100E0B4DD /* Route.swift in Sources */,
 				CA5380CB1C5C195900204A68 /* UIColor+AstroGadgets.swift in Sources */,
+				3ED7EA386EBCBC334F309446 /* NetworkServiceLogger.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -511,13 +520,15 @@
 				2E9342BC5B4FE98B693084A6 /* UIView+AstroGadgetsSpec.swift in Sources */,
 				E6F32EE51D6264FE00D31F64 /* NibLoadableViewSpec.swift in Sources */,
 				63379D811C063BA900DDD95B /* KeychainAccessSpec.swift in Sources */,
-				3F8E16F51CCA801000E0B4DD /* NetworkServiceSpec.swift in Sources */,
 				B69726CE1BD9162F0047EEB9 /* LoggerSpec.swift in Sources */,
 				CA5380CD1C5C196E00204A68 /* UIColor+AstroGadgetsSpec.swift in Sources */,
 				2E934D1B02F8932284DCF220 /* UIViewController+AstroGadgetsSpec.swift in Sources */,
 				3FCD95D71CCC2D3400A5442F /* User.swift in Sources */,
 				E62F9D221D623675005402BF /* ReusableViewSpec.swift in Sources */,
 				BD62EA4B1C929C1C004A02DF /* EnumCountableSpec.swift in Sources */,
+				3ED7E0B3E861F8023637D769 /* NetworkRequestLoggerSpec.swift in Sources */,
+				3ED7E70C2A0CC260E6CB6884 /* NetworkServiceSpec.swift in Sources */,
+				3ED7E5160B9194EFD65AD935 /* SpecHelpers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Astro/Networking/NetworkService.swift
+++ b/Astro/Networking/NetworkService.swift
@@ -342,7 +342,7 @@ public class NetworkService: NetworkServiceType {
     
     public func requestData(URLRequest: URLRequestConvertible) -> Task<Float, ResponseValue<NSData>, NetworkError> {
         return Task { [weak self] progress, fulfill, reject, configure in
-            self?.postNotification(NetworkService.Notifications.DidRequest, request: URLRequest)
+            NetworkService.postNotification(NetworkService.Notifications.DidRequest, request: URLRequest)
 
             let request = self?.requestManager.request(URLRequest)
                 .progress { bytesRead, totalBytesRead, totalExpectedBytes -> Void in
@@ -350,7 +350,7 @@ public class NetworkService: NetworkServiceType {
                 }
                 .validate() // Covers error status code and content type mismatch
                 .responseData { response in
-                    self?.postNotification(NetworkService.Notifications.DidReceive, request: URLRequest, response: response)
+                    NetworkService.postNotification(NetworkService.Notifications.DidReceive, request: URLRequest, response: response)
 
                     guard let data = response.result.value where response.result.isSuccess else {
                         // We should always have an error in the non success case but use AssertionError to avoid a bang (!)
@@ -428,7 +428,7 @@ public extension NetworkService {
         - parameter request: The request made by the network service
         - parameter response: The response received by the network service. This will only have a value for Notifications.DidReceive
     */
-    private func postNotification(notificationName: String, request: URLRequestConvertible, response: Response<NSData, NSError>? = nil) {
+    private static func postNotification(notificationName: String, request: URLRequestConvertible, response: Response<NSData, NSError>? = nil) {
         let info = NotificationInfo(request: request, response: response)
 
         NSNotificationCenter.defaultCenter().postNotificationName(notificationName, object: self, userInfo: [NetworkService.NotificationInfoKey: info])

--- a/Astro/Networking/NetworkService.swift
+++ b/Astro/Networking/NetworkService.swift
@@ -369,24 +369,65 @@ public class NetworkService: NetworkServiceType {
 
 public extension NetworkService {
     public struct Notifications {
+        /**
+            Notification for when a request is submitted. The `userInfo` dictionary will contain an instance of `NetworkService.NotificationInfo` via the `NotificationInfoKey` key. For example,
+            ```
+            func networkServiceDidRequest(notification: Notification) {
+                let info = userInfo?[NetworkService.NotificationInfoKey] as? NetworkService.NotificationInfo
+                NSLog("request: \(info.request)")
+            }
+            ```
+        */
         public static let DidRequest = "astro.networkingservice.notifications.didRequest"
+
+        /**
+            Notification for when a response is received. The `userInfo` dictionary will contain an instance of `NetworkService.NotificationInfo` via the `NotificationInfoKey` key. For example,
+            ```
+            func networkServiceDidReceive(notification: Notification) {
+                let info = userInfo?[NetworkService.NotificationInfoKey] as? NetworkService.NotificationInfo
+                NSLog("response: \(info.response)")
+            }
+            ```
+        */
         public static let DidReceive = "astro.networkingservice.notifications.didReceive"
     }
 
+    /**
+        The key to the network notification info in the notification `userInfo` dictionary
+    */
     public static let NotificationInfoKey = "NotificationInfo"
 
-    // This is a box/wrapper for the request and response because we can't directly
-    // add the response to the UserInfo dict (since it's not an NSObject)
+    /**
+     This is a box/wrapper for the request and response because we can't directly add the response to the UserInfo dict (since it's not an NSObject)
+    */
     public class NotificationInfo: NSObject {
+        /**
+            The request that was performed by the NetworkService
+        */
         public let request: NSMutableURLRequest
+
+        /**
+            The response that is received in response to `request`. This value will only have a value for the `Notifications.DidReceive` notification.
+        */
         public let response: Response<NSData, NSError>?
 
+        /**
+            Creates an instance with the specified request and optional response.
+            - parameter request: the request being performed by the NetworkService
+            - parameter response: an option response received by the NetworkService
+        */
         private init(request: URLRequestConvertible, response: Response<NSData, NSError>? = nil) {
             self.request = request.URLRequest
             self.response = response
         }
     }
 
+    /**
+        Posts a network notification for the given request and response.
+        - parameter notficationName: The name of the notification. This should be one of the notification constants in NetworkService.Notifications (.DidRequest and .DidReceive)
+        - parameter request: The request made by the network service
+        - parameter response: The response received by the network service. This will only have a value for Notifications.DidReceive
+    */
     private func postNotification(notificationName: String, request: URLRequestConvertible, response: Response<NSData, NSError>? = nil) {
         let info = NotificationInfo(request: request, response: response)
 

--- a/Astro/Networking/NetworkServiceLogger.swift
+++ b/Astro/Networking/NetworkServiceLogger.swift
@@ -12,32 +12,60 @@
 import Foundation
 import Alamofire
 
+/**
+    A simple logger that listens for NetworkService request/response events and logs the related information in a nicely formatted message for debugging.
+*/
 public class NetworkServiceLogger: NSObject {
 
+    /**
+        Use this instance for the simplest use case. For example, starting the logger can be as simple as:
+         ```
+            NetworkServiceLogger.sharedInstance.start()
+         ```
+    */
     public static let sharedInstance = NetworkServiceLogger()
 
+    /**
+        Set this option to include or exclude the request and response headers in the formatted log message. Defaults to false (forced to true when logging response errors).
+    */
     public var includeHeaders = false
+
+    /**
+        Set this option to include or exclude the request and response body in the formatted log message. Defaults to true (forced to true when logging response errors).
+    */
     public var includeBody = true
 
     deinit {
         stop()
     }
 
+    /**
+        Starts observing and logging network service notifications.
+    */
     public func start() {
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(didRequest(_:)), name: NetworkService.Notifications.DidRequest, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(didReceive(_:)), name: NetworkService.Notifications.DidReceive, object: nil)
     }
 
+    /**
+        Stops observing and logging network service notifications.
+    */
     public func stop() {
         NSNotificationCenter.defaultCenter().removeObserver(self)
     }
 
+    /**
+        Internal method for handling request notifications
+    */
     func didRequest(notification: NSNotification) {
         guard let request = notification.info?.request else { return }
 
         Log.info(request.debugDescription(headers: includeHeaders, body: includeBody))
     }
 
+    /**
+        Internal method for handling response notifications
+    */
     func didReceive(notification: NSNotification) {
         guard let response = notification.info?.response else { return }
 
@@ -51,12 +79,21 @@ public class NetworkServiceLogger: NSObject {
 }
 
 private extension NSNotification {
+    /**
+        Private convenience extension to make extracting the network info from the notification simple.
+    */
     var info: NetworkService.NotificationInfo? {
         return userInfo?[NetworkService.NotificationInfoKey] as? NetworkService.NotificationInfo
     }
 }
 
 private extension NSMutableURLRequest {
+    /**
+        Private extension for formatting a request into a debug string.
+        - parameter headers: option to include request headers in the output
+        - parameter body: option to include the request body in the output
+        - returns: A formatted string representing the request
+    */
     func debugDescription(headers includeHeaders: Bool = false, body includeBody: Bool = false) -> String {
         let method = HTTPMethod
         let url = URL?.absoluteString ?? ""
@@ -65,7 +102,7 @@ private extension NSMutableURLRequest {
         if includeHeaders {
             let headers = allHTTPHeaderFields?.map { "\($0): \($1)" }
             if let headers = headers {
-                result.appendContentsOf(": \(headers)")
+                result.appendContentsOf(":\n\(headers)\n")
             }
         }
 
@@ -81,6 +118,12 @@ private extension NSMutableURLRequest {
 }
 
 private extension Response {
+    /**
+        Private extension for formatting a response into a debug string.
+        - parameter headers: option to include response headers in the output
+        - parameter body: option to include the response body in the output
+        - returns: A formatted string representing the response
+    */
     func debugDescription(headers includeHeaders: Bool = false, body includeBody: Bool = false) -> String {
         let statusCode = HTTPStatusCode(intValue: response?.statusCode ?? 0)
         let durationMillis = Int(timeline.totalDuration * 1000)
@@ -91,7 +134,7 @@ private extension Response {
         if includeHeaders || statusCode?.isError == true {
             let headers = response?.allHeaderFields.map { "\($0): \($1)" }
             if let headers = headers {
-                result.appendContentsOf(": \(headers)")
+                result.appendContentsOf(":\n\(headers)\n")
             }
         }
 

--- a/Astro/Networking/NetworkServiceLogger.swift
+++ b/Astro/Networking/NetworkServiceLogger.swift
@@ -1,0 +1,107 @@
+//  Copyright © 2016 Robots and Pencils, Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+//  Neither the name of the Robots and Pencils, Inc. nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+//
+//  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import Foundation
+import Alamofire
+
+public class NetworkServiceLogger: NSObject {
+
+    public static let sharedInstance = NetworkServiceLogger()
+
+    public var includeHeaders = false
+    public var includeBody = true
+
+    deinit {
+        stop()
+    }
+
+    public func start() {
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(didRequest(_:)), name: NetworkService.Notifications.DidRequest, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(didReceive(_:)), name: NetworkService.Notifications.DidReceive, object: nil)
+    }
+
+    public func stop() {
+        NSNotificationCenter.defaultCenter().removeObserver(self)
+    }
+
+    func didRequest(notification: NSNotification) {
+        guard let request = notification.info?.request else { return }
+
+        Log.info(request.debugDescription(headers: includeHeaders, body: includeBody))
+    }
+
+    func didReceive(notification: NSNotification) {
+        guard let response = notification.info?.response else { return }
+
+        switch response.result {
+        case .Failure(let error):
+            Log.error(response.debugDescription(headers: includeHeaders, body: includeBody) + ": \(error)")
+        case .Success:
+            Log.info(response.debugDescription(headers: includeHeaders, body: includeBody))
+        }
+    }
+}
+
+private extension NSNotification {
+    var info: NetworkService.NotificationInfo? {
+        return userInfo?[NetworkService.NotificationInfoKey] as? NetworkService.NotificationInfo
+    }
+}
+
+private extension NSMutableURLRequest {
+    func debugDescription(headers includeHeaders: Bool = false, body includeBody: Bool = false) -> String {
+        let method = HTTPMethod
+        let url = URL?.absoluteString ?? ""
+        var result = "\(method) \(url)"
+
+        if includeHeaders {
+            let headers = allHTTPHeaderFields?.map { "\($0): \($1)" }
+            if let headers = headers {
+                result.appendContentsOf(": \(headers)")
+            }
+        }
+
+        if includeBody {
+            if let bodyData = HTTPBody,
+            body = String(data: bodyData, encoding: NSUTF8StringEncoding) {
+                result.appendContentsOf("\n")
+                result.appendContentsOf(body)
+            }
+        }
+        return result
+    }
+}
+
+private extension Response {
+    func debugDescription(headers includeHeaders: Bool = false, body includeBody: Bool = false) -> String {
+        let statusCode = HTTPStatusCode(intValue: response?.statusCode ?? 0)
+        let durationMillis = Int(timeline.totalDuration * 1000)
+        let url = request?.URL?.absoluteString ?? ""
+        let status = statusCode.flatMap { "\($0.rawValue)" } ?? ""
+        var result = "[\(durationMillis)ms] \(status) \(url)"
+
+        if includeHeaders || statusCode?.isError == true {
+            let headers = response?.allHeaderFields.map { "\($0): \($1)" }
+            if let headers = headers {
+                result.appendContentsOf(": \(headers)")
+            }
+        }
+
+        if includeBody || statusCode?.isError == true {
+            if let bodyData = self.data,
+            body = String(data: bodyData, encoding: NSUTF8StringEncoding) {
+                result.appendContentsOf("\n")
+                result.appendContentsOf(body)
+            }
+        }
+        return result
+    }
+}

--- a/AstroTests/Unit Tests/Logging/LoggerSpec.swift
+++ b/AstroTests/Unit Tests/Logging/LoggerSpec.swift
@@ -13,18 +13,17 @@ import Quick
 import Nimble
 @testable import Astro
 
+class LogRecorder: Logger {
+    var messages = [String]()
+
+    func log(level: Log.Level, message: String) {
+        messages.append(message)
+    }
+}
+
 class LogSpec: QuickSpec {
-    
     override func spec() {
 
-        class LogRecorder: Logger {
-            var messages = [String]()
-            
-            func log(level: Log.Level, message: String) {
-                messages.append(message)
-            }
-        }
-        
         let generateLogs = { () -> () in
             Log.debug("debug")
             Log.info("info")

--- a/AstroTests/Unit Tests/Networking/NetworkRequestLoggerSpec.swift
+++ b/AstroTests/Unit Tests/Networking/NetworkRequestLoggerSpec.swift
@@ -1,0 +1,91 @@
+//  Copyright © 2016 Robots and Pencils, Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+//  Neither the name of the Robots and Pencils, Inc. nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+//
+//  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import Quick
+import Nimble
+import Nocilla
+import Alamofire
+import Freddy
+@testable import Astro
+
+class NetworkServiceLoggerSpec: QuickSpec {
+    override func spec() {
+        beforeSuite {
+            LSNocilla.sharedInstance().start()
+        }
+        afterSuite {
+            LSNocilla.sharedInstance().stop()
+        }
+        afterEach {
+            LSNocilla.sharedInstance().clearStubs()
+        }
+
+        var subject: NetworkServiceLogger!
+        var networkService: NetworkService!
+        var json: JSON!
+        var request: NSMutableURLRequest!
+        var logRecorder: LogRecorder!
+
+        beforeEach {
+            json = [
+                "field1": "value1",
+                "field2": "value2"
+            ]
+            request = NSMutableURLRequest(URL: NSURL(string: "https://example.com/logger/path")!)
+
+            logRecorder = LogRecorder()
+            Log.logger = logRecorder
+            Log.level = .Debug
+
+            networkService = NetworkService()
+
+            subject = NetworkServiceLogger()
+        }
+
+        context("not started") {
+            beforeEach {
+                stubAnyRequest().andReturn(.Code200OK).withJSON(json)
+                networkService.requestData(request).waitUntilDone()
+            }
+
+            it("should not log until started") {
+                expect(logRecorder.messages).to(beEmpty())
+            }
+        }
+
+        context("started") {
+            beforeEach {
+                subject.start()
+
+                stubAnyRequest().andReturn(.Code200OK).withJSON(json)
+                networkService.requestData(request).waitUntilDone()
+            }
+
+            it("logs send and receive messages") {
+                expect(logRecorder.messages).to(haveCount(2))
+            }
+
+            context("stopped") {
+                beforeEach {
+                    logRecorder.messages.removeAll()
+                    subject.stop()
+
+                    stubAnyRequest().andReturn(.Code200OK).withJSON(json)
+                    networkService.requestData(request).waitUntilDone()
+                }
+
+                it("should not log after stopping") {
+                    expect(logRecorder.messages).to(beEmpty())
+                }
+            }
+        }
+    }
+}

--- a/AstroTests/Unit Tests/Networking/NetworkRequestLoggerSpec.swift
+++ b/AstroTests/Unit Tests/Networking/NetworkRequestLoggerSpec.swift
@@ -87,5 +87,19 @@ class NetworkServiceLoggerSpec: QuickSpec {
                 }
             }
         }
+
+        context("network service not retained") {
+            beforeEach {
+                subject.start()
+
+                stubAnyRequest().andReturn(.Code200OK).withJSON(json)
+
+                NetworkService().requestData(request)
+            }
+
+            it("should log both send and receive messages") {
+                expect(logRecorder.messages).toEventually(haveCount(2))
+            }
+        }
     }
 }

--- a/AstroTests/Unit Tests/Networking/NetworkServiceSpec.swift
+++ b/AstroTests/Unit Tests/Networking/NetworkServiceSpec.swift
@@ -449,27 +449,3 @@ public func ==(a: JSON.Error, b: JSON.Error) -> Bool {
     default: return false
     }
 }
-
-// Improved DSL for Nocilla
-
-func stubRoute(route: Route) -> LSStubRequestDSL {
-    return stubRequest(route.method.rawValue, route.URL.absoluteString).withHeaders(route.URLRequest.allHTTPHeaderFields).withBody(route.URLRequest.HTTPBody)
-}
-
-extension LSStubRequestDSL {
-    func andReturn(status: HTTPStatusCode) -> LSStubResponseDSL {
-        return andReturn(status.rawValue)
-    }
-}
-
-extension LSStubResponseDSL {
-    func withJSON(json: JSON) -> LSStubResponseDSL {
-        let body = try? json.serialize() ?? NSData()
-        return withHeader("Content-Type", "application/json").withBody(body)
-    }
-}
-
-func stubAnyRequest() -> LSStubRequestDSL {
-    return stubRequest(nil, ".*".regex())
-}
-

--- a/AstroTests/Unit Tests/SpecHelpers.swift
+++ b/AstroTests/Unit Tests/SpecHelpers.swift
@@ -1,0 +1,53 @@
+//  Copyright © 2016 Robots and Pencils, Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+//  Neither the name of the Robots and Pencils, Inc. nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+//
+//  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import Quick
+import Nimble
+import Nocilla
+import Freddy
+import SwiftTask
+@testable import Astro
+
+// Wait for a task to complete to reduce dependence on `toEventually()` for async tests
+
+extension Task {
+    func waitUntilDone() {
+        waitUntil(timeout: 5) { done in
+            self.then { _, _ in
+                done()
+            }
+        }
+    }
+}
+
+// Improved DSL for Nocilla
+
+func stubRoute(route: Route) -> LSStubRequestDSL {
+    return stubRequest(route.method.rawValue, route.URL.absoluteString).withHeaders(route.URLRequest.allHTTPHeaderFields).withBody(route.URLRequest.HTTPBody)
+}
+
+extension LSStubRequestDSL {
+    func andReturn(status: HTTPStatusCode) -> LSStubResponseDSL {
+        return andReturn(status.rawValue)
+    }
+}
+
+extension LSStubResponseDSL {
+    func withJSON(json: JSON) -> LSStubResponseDSL {
+        let body = try? json.serialize() ?? NSData()
+        return withHeader("Content-Type", "application/json").withBody(body)
+    }
+}
+
+func stubAnyRequest() -> LSStubRequestDSL {
+    return stubRequest(nil, ".*".regex())
+}
+

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Astro is a library, built in swift, used to hold common utility methods.
     - [HTTPStatusCode](#httpstatuscode)
     - [Route](#route)
     - [NetworkService](#networkservice)
+    - [NetworkServiceLogger](#networkservicelogger)
   - [Security](#security)
   - [UI](#ui)
     - [UIColor Extension](#uicolor-extension)
@@ -172,6 +173,22 @@ Now you can easily stub your login `Route` like this:
 
 ```swift
 stubRoute(Route.login(username: "user", password: "pass")).andReturn(.Code200OK).withJSON(["token": "[TOKEN]"])
+```
+
+#### NetworkServiceLogger
+
+`NetworkServiceLogger` logs HTTP requests and responses issued by `NetworkService`. Usage is pretty simple:
+
+```swift
+// Optionally enable or disable output of headers and body
+NetworkServiceLogger.sharedInstance.includeHeaders = true
+NetworkServiceLogger.sharedInstance.includeBody = true
+
+// Start logging
+NetworkServiceLogger.sharedInstance.start()
+
+// Stop logging
+NetworkServiceLogger.sharedInstance.stop()
 ```
 
 ### Security


### PR DESCRIPTION
The motivation for this change was two-fold. First, client applications sometimes need to handle certain response codes (like 401 Unauthorized) in a generic fashion without having specify this handling at every request call-site. Second, to have an easy to log network request and response details.

# Changes
* Posts notifications for NetworkService requests and responses
* Adds `NetworkRequestLogger` that observes the new notifications and logs details about the requests and responses
