### PR TITLE
Fix awkward request parameter values to be Any instead of AnyObject

### DIFF
--- a/Astro.podspec
+++ b/Astro.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "Astro"
-  s.version      = "3.0.0"
+  s.version      = "3.0.1"
   s.summary          = "A RoboPod containing a small collection of utilities for project reuse"
   s.homepage         = "https://RobotsAndPencils.com"
   s.license      = {

--- a/Astro/Networking/Route.swift
+++ b/Astro/Networking/Route.swift
@@ -65,7 +65,7 @@ extension Route: CustomStringConvertible {
 
 public enum RequestParameters {
     case json(parameters: Freddy.JSON)
-    case dictionary(parameters: [String: AnyObject], parameterEncoding: Alamofire.ParameterEncoding)
+    case dictionary(parameters: [String: Any], parameterEncoding: Alamofire.ParameterEncoding)
 
     public func encode(_ URLRequest: URLRequest) -> (URLRequest, NSError?) {
         switch self {


### PR DESCRIPTION
This issue was discovered while migrating a large project to Swift 3. It is inconvenient for request parameter values to be `AnyObject` since it requires casting. This change does not break the api since `Any` is more inclusive than `AnyObject`.