### PR TITLE
Add constrain function in Comparable extension file

### DIFF
--- a/Astro.podspec
+++ b/Astro.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "Astro"
-  s.version      = "3.0.1"
+  s.version      = "3.1.0"
   s.summary          = "A RoboPod containing a small collection of utilities for project reuse"
   s.homepage         = "https://RobotsAndPencils.com"
   s.license      = {

--- a/Astro.xcodeproj/project.pbxproj
+++ b/Astro.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		63379D811C063BA900DDD95B /* KeychainAccessSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63379D801C063BA900DDD95B /* KeychainAccessSpec.swift */; };
 		6367D7851C0BCC6C0045BDFE /* testdata.json in Resources */ = {isa = PBXBuildFile; fileRef = 6367D7841C0BCC6C0045BDFE /* testdata.json */; };
 		638C62521BD454FD0004ECE1 /* Astro.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 638C62471BD454FD0004ECE1 /* Astro.framework */; };
+		835932AC62597B13CED887E4 /* ComparableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83593E90B43887E2AE664086 /* ComparableSpec.swift */; };
+		835937E4D0DE85A9286BACC6 /* Comparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83593EEFC7D26F39183B2AE1 /* Comparable.swift */; };
 		B69726CE1BD9162F0047EEB9 /* LoggerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69726CD1BD9162F0047EEB9 /* LoggerSpec.swift */; };
 		BD62EA481C929BF0004A02DF /* EnumCountable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD62EA471C929BF0004A02DF /* EnumCountable.swift */; };
 		BD62EA4B1C929C1C004A02DF /* EnumCountableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD62EA4A1C929C1C004A02DF /* EnumCountableSpec.swift */; };
@@ -81,6 +83,8 @@
 		638C62511BD454FD0004ECE1 /* AstroTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AstroTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		638C62581BD454FD0004ECE1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7CC6FB4E4A3FE9D093738307 /* Pods-AstroTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AstroTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AstroTests/Pods-AstroTests.debug.xcconfig"; sourceTree = "<group>"; };
+		83593E90B43887E2AE664086 /* ComparableSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ComparableSpec.swift; path = Utils/ComparableSpec.swift; sourceTree = "<group>"; };
+		83593EEFC7D26F39183B2AE1 /* Comparable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Comparable.swift; path = Utils/Comparable.swift; sourceTree = "<group>"; };
 		B69726CD1BD9162F0047EEB9 /* LoggerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoggerSpec.swift; sourceTree = "<group>"; };
 		BD62EA471C929BF0004A02DF /* EnumCountable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EnumCountable.swift; path = Utils/EnumCountable.swift; sourceTree = "<group>"; };
 		BD62EA4A1C929C1C004A02DF /* EnumCountableSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EnumCountableSpec.swift; path = Utils/EnumCountableSpec.swift; sourceTree = "<group>"; };
@@ -253,6 +257,8 @@
 			children = (
 				3F78B54F1CC35D4900A0E30C /* Queue.swift */,
 				BD62EA471C929BF0004A02DF /* EnumCountable.swift */,
+				83593EEFC7D26F39183B2AE1 /* Comparable.swift */,
+				83593E90B43887E2AE664086 /* ComparableSpec.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -510,6 +516,7 @@
 				3F8E16FB1CCA843100E0B4DD /* Route.swift in Sources */,
 				CA5380CB1C5C195900204A68 /* UIColor+AstroGadgets.swift in Sources */,
 				3ED7EA386EBCBC334F309446 /* NetworkServiceLogger.swift in Sources */,
+				835937E4D0DE85A9286BACC6 /* Comparable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -531,6 +538,7 @@
 				3ED7E0B3E861F8023637D769 /* NetworkRequestLoggerSpec.swift in Sources */,
 				3ED7E70C2A0CC260E6CB6884 /* NetworkServiceSpec.swift in Sources */,
 				3ED7E5160B9194EFD65AD935 /* SpecHelpers.swift in Sources */,
+				835932AC62597B13CED887E4 /* ComparableSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Astro/Utils/Comparable.swift
+++ b/Astro/Utils/Comparable.swift
@@ -1,0 +1,16 @@
+//  Copyright © 2016 Robots and Pencils, Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+//  Neither the name of the Robots and Pencils, Inc. nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+//
+//  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import Foundation
+
+func clamp<T: Comparable>(_ x: T, min minimum: T, max maximum: T) -> T {
+    return max(minimum, min(maximum, x))
+}

--- a/Astro/Utils/ComparableSpec.swift
+++ b/Astro/Utils/ComparableSpec.swift
@@ -1,0 +1,52 @@
+//  Copyright © 2016 Robots and Pencils, Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+//  Neither the name of the Robots and Pencils, Inc. nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+//
+//  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import Quick
+import Nimble
+@testable import Astro
+
+class ComparableSpec: QuickSpec {
+    override func spec() {
+        describe("clamp") {
+            context("x is less than min") {
+                it("returns min") {
+                    let result = clamp(0, min: 5, max: 10)
+                    expect(result).to(equal(5))
+                }
+            }
+            context("x is equal to min") {
+                it("returns min") {
+                    let result = clamp(5, min: 5, max: 10)
+                    expect(result).to(equal(5))
+                }
+            }
+            context("x is between min and max") {
+                it("returns x") {
+                    let result = clamp(5, min: 0, max: 10)
+                    expect(result).to(equal(5))
+                }
+            }
+            context("x is equal to max") {
+                it("returns max") {
+                    let result = clamp(10, min: 5, max: 10)
+                    expect(result).to(equal(10))
+                }
+            }
+            context("x is greater than max") {
+                it("returns max") {
+                    let result = clamp(10, min: 0, max: 5)
+                    expect(result).to(equal(5))
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
This adds a simple generic `constrain` function that does `max(minimum, min(maximum, x))`. I've probably implemented this in every project and find it really useful, so it seems like this would be a good place for it. 😄 

Unit tests are included.