### PR TITLE
Feature/add keychain accessor

### DIFF
--- a/Astro/Security/KeychainAccess.swift
+++ b/Astro/Security/KeychainAccess.swift
@@ -23,6 +23,35 @@ let KeychainAccessServiceBundleID: String = {
 
 let KeychainAccessErrorDomain = "\(KeychainAccessServiceBundleID).error"
 
+enum KeychainAccessibleAttribute {
+    case WhenUnlocked
+    case AfterFirstUnlock
+    case Always
+    case WhenPasscodeSetThisDeviceOnly
+    case WhenUnlockedThisDeviceOnly
+    case AfterFirstUnlockThisDeviceOnly
+    case AlwaysThisDeviceOnly
+
+    func secAttrValue() -> CFString {
+        switch self {
+        case .WhenUnlocked:
+            return kSecAttrAccessibleWhenUnlocked
+        case .AfterFirstUnlock:
+            return kSecAttrAccessibleAfterFirstUnlock
+        case .Always:
+            return kSecAttrAccessibleAlways
+        case .WhenPasscodeSetThisDeviceOnly:
+            return kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly
+        case .WhenUnlockedThisDeviceOnly:
+            return kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        case .AfterFirstUnlockThisDeviceOnly:
+            return kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        case .AlwaysThisDeviceOnly:
+            return kSecAttrAccessibleAlwaysThisDeviceOnly
+        }
+    }
+}
+
 /**
  KeychainAccess provides the app access to a device's Keychain store. Usage is fairly straightforward, as part of an account, you can place strings (or data) for a key into the Keychain and then retrieve those values later. This makes it a good way to securely store a specific user's password or tokens for reuse in the app.
  */

--- a/Astro/Security/KeychainAccess.swift
+++ b/Astro/Security/KeychainAccess.swift
@@ -78,7 +78,7 @@ open class KeychainAccess {
         guard let data = self.get(key, accessibleAttribute: accessibleAttribute) else {
             return nil
         }
-        return NSString(data: data, encoding: String.Encoding.utf8.rawValue) as? String
+        return String(data: data, encoding: String.Encoding.utf8)
     }
     
     /**
@@ -157,7 +157,7 @@ open class KeychainAccess {
             if status == errSecSuccess {
                 return true
             }
-            Log.debug("Failed to add data to keychain with status=\(status). Attempted to add data [\(data)] for key [\(key)]")
+            Log.debug("Failed to add data to keychain with status=\(status). Attempted to add data [\(String(describing: data))] for key [\(key)]")
             return false
         } else {
             Log.debug("Failed to add key to keychain with status=\(status). Attempted to add key [\(key)]")

--- a/AstroTests/Unit Tests/Security/KeychainAccessSpec.swift
+++ b/AstroTests/Unit Tests/Security/KeychainAccessSpec.swift
@@ -22,125 +22,219 @@ class KeychainAccessSpec: QuickSpec {
             var testKey = "AccessKey"
             
             afterEach {
-                _ = keychain.delete(testKey)
-            }
-            
-            it("returns nil for retrieving a key that doesn't exist") {
-                let storedString = keychain.getString(testKey)
-                expect(storedString).to(beNil())
+                _ = keychain.delete(testKey, accessibleAttribute: .WhenUnlocked)
             }
 
-            it("can store and retrieve a string") {
-                let testString = "something really boring"
-                _ = keychain.putString(testKey, value: testString)
-                
-                let storedString = keychain.getString(testKey)
-                expect(storedString).to(equal(testString))
-            }
-            
-            it("can store and retrieve data") {
-                testKey = "DataKey"
-                guard let testFilePath = Bundle(for: KeychainAccessSpec.self).url(forResource: "testdata", withExtension: "json") else {
-                    fail("no test file")
-                    return
+            context("and you want it available when unlocked") {
+
+                it("returns nil for retrieving a key that doesn't exist") {
+                    let storedString = keychain.getString(testKey, accessibleAttribute: .WhenUnlocked)
+                    expect(storedString).to(beNil())
                 }
-                let testData = try! Data(contentsOf: testFilePath)
-                _ = keychain.put(testKey, data: testData)
-                
-                let storedData = keychain.get(testKey)
-                expect(storedData).toNot(beNil())
-                expect(storedData).to(equal(testData))
-            }
-            
-            it("can set a string value to nil") {
-                _ = keychain.putString(testKey, value: nil)
-                
-                let storedString = keychain.getString(testKey)
-                expect(storedString).to(beNil())
-            }
-            
-            it("can set a data value to nil") {
-                _ = keychain.putString(testKey, value: nil)
-                
-                let storedData = keychain.get(testKey)
-                expect(storedData).to(beNil())
-            }
-            
-            it("can be accessed using subscripting for strings") {
-                let testString = "something slightly less boring"
-                keychain[testKey] = testString
-                
-                let storedString = keychain[testKey]
-                expect(storedString).to(equal(testString))
-            }
-            
-            it("can be accessed using subscripting for data") {
-                testKey = "DataKey"
-                guard let testFilePath = Bundle(for: KeychainAccessSpec.self).url(forResource: "testdata", withExtension: "json") else {
-                    fail("no test file")
-                    return
+
+                it("can store and retrieve a string") {
+                    let testString = "something really boring"
+                    _ = keychain.putString(testKey, value: testString, accessibleAttribute: .WhenUnlocked)
+
+                    let storedString = keychain.getString(testKey, accessibleAttribute: .WhenUnlocked)
+                    expect(storedString).to(equal(testString))
                 }
-                let testData = try! Data(contentsOf: testFilePath)
-                keychain[data: testKey] = testData
-                
-                let storedData = keychain[data: testKey]
-                expect(storedData).toNot(beNil())
-                expect(storedData).to(equal(testData))
+
+                it("can store and retrieve data") {
+                    testKey = "DataKey"
+                    guard let testFilePath = Bundle(for: KeychainAccessSpec.self).url(forResource: "testdata", withExtension: "json") else {
+                        fail("no test file")
+                        return
+                    }
+                    let testData = try! Data(contentsOf: testFilePath)
+                    _ = keychain.put(testKey, data: testData, accessibleAttribute: .WhenUnlocked)
+
+                    let storedData = keychain.get(testKey, accessibleAttribute: .WhenUnlocked)
+                    expect(storedData).toNot(beNil())
+                    expect(storedData).to(equal(testData))
+                }
+
+                it("can set a string value to nil") {
+                    _ = keychain.putString(testKey, value: nil, accessibleAttribute: .WhenUnlocked)
+
+                    let storedString = keychain.getString(testKey, accessibleAttribute: .WhenUnlocked)
+                    expect(storedString).to(beNil())
+                }
+
+                it("can set a data value to nil") {
+                    _ = keychain.putString(testKey, value: nil, accessibleAttribute: .WhenUnlocked)
+
+                    let storedData = keychain.get(testKey, accessibleAttribute: .WhenUnlocked)
+                    expect(storedData).to(beNil())
+                }
+
+                it("can be accessed using subscripting for strings") {
+                    let testString = "something slightly less boring"
+                    keychain[testKey] = testString
+
+                    let storedString = keychain[testKey]
+                    expect(storedString).to(equal(testString))
+                }
+
+                it("can be accessed using subscripting for data") {
+                    testKey = "DataKey"
+                    guard let testFilePath = Bundle(for: KeychainAccessSpec.self).url(forResource: "testdata", withExtension: "json") else {
+                        fail("no test file")
+                        return
+                    }
+                    let testData = try! Data(contentsOf: testFilePath)
+                    keychain[data: testKey] = testData
+
+                    let storedData = keychain[data: testKey]
+                    expect(storedData).toNot(beNil())
+                    expect(storedData).to(equal(testData))
+                }
+
+                it("can override a value") {
+                    let origString = "exciting stuff?"
+                    let finalString = "boring stuff?"
+
+                    _ = keychain.putString(testKey, value: origString, accessibleAttribute: .WhenUnlocked)
+                    let storedOrigString = keychain.getString(testKey, accessibleAttribute: .WhenUnlocked)
+                    expect(storedOrigString).to(equal(origString))
+
+                    _ = keychain.putString(testKey, value: finalString, accessibleAttribute: .WhenUnlocked)
+                    let storedFinalString = keychain.getString(testKey, accessibleAttribute: .WhenUnlocked)
+                    expect(storedFinalString).to(equal(finalString))
+                }
+
+                it("can delete a value") {
+                    let testString = "exciting stuff?"
+                    _ = keychain.putString(testKey, value: testString, accessibleAttribute: .WhenUnlocked)
+                    let storedString = keychain.getString(testKey, accessibleAttribute: .WhenUnlocked)
+                    _ = keychain.putString(testKey, value: nil, accessibleAttribute: .WhenUnlocked)
+
+                    let storedNil = keychain.getString(testKey, accessibleAttribute: .WhenUnlocked)
+                    expect(storedString).to(equal(testString))
+                    expect(storedNil).to(beNil())
+                }
+
+                it("can delete all keys and data for the app") {
+                    // Push in a key/data element and verify it exists
+                    let testString = "exciting stuff?"
+                    _ = keychain.putString(testKey, value: testString, accessibleAttribute: .WhenUnlocked)
+                    var storedString = keychain.getString(testKey, accessibleAttribute: .WhenUnlocked)
+                    expect(storedString).to(equal(testString))
+
+                    // Delete everything and then verify you can't access the key/data any more
+                    let status = keychain.deleteAllKeysAndDataForApp()
+                    expect(status).to(beTrue())
+                    storedString = keychain.getString(testKey, accessibleAttribute: .WhenUnlocked)
+                    expect(storedString).to(beNil())
+                }
+
+                it("can't access a key from a different account") {
+                    testKey = "SuperSecretKey"
+                    let testString = "you can't see me"
+
+                    // Push in a key/data element and verify it exists in the main account
+                    _ = keychain.putString(testKey, value: testString, accessibleAttribute: .WhenUnlocked)
+                    var storedString = keychain.getString(testKey, accessibleAttribute: .WhenUnlocked)
+                    expect(storedString).to(equal(testString))
+                    
+                    // Try to gain access to a key from another account
+                    let otherKeychain = KeychainAccess(account: "SomeOtherAccount@RobotsAndPencils.com")
+                    storedString = otherKeychain.getString(testKey, accessibleAttribute: .WhenUnlocked)
+                    expect(storedString).to(beNil())
+                }
             }
-            
-            it("can override a value") {
-                let origString = "exciting stuff?"
-                let finalString = "boring stuff?"
 
-                _ = keychain.putString(testKey, value: origString)
-                let storedOrigString = keychain.getString(testKey)
-                expect(storedOrigString).to(equal(origString))
-                
-                _ = keychain.putString(testKey, value: finalString)
-                let storedFinalString = keychain.getString(testKey)
-                expect(storedFinalString).to(equal(finalString))
+            context("and you want it just on that device") {
+
+                it("can store and retrieve a string") {
+                    let testString = "something really boring"
+                    _ = keychain.putString(testKey, value: testString, accessibleAttribute: .WhenUnlockedThisDeviceOnly)
+
+                    let storedString = keychain.getString(testKey, accessibleAttribute: .WhenUnlockedThisDeviceOnly)
+                    expect(storedString).to(equal(testString))
+                }
+
+                it("can store and retrieve data") {
+                    testKey = "DataKey"
+                    guard let testFilePath = Bundle(for: KeychainAccessSpec.self).url(forResource: "testdata", withExtension: "json") else {
+                        fail("no test file")
+                        return
+                    }
+                    let testData = try! Data(contentsOf: testFilePath)
+                    _ = keychain.put(testKey, data: testData, accessibleAttribute: .WhenUnlockedThisDeviceOnly)
+
+                    let storedData = keychain.get(testKey, accessibleAttribute: .WhenUnlockedThisDeviceOnly)
+                    expect(storedData).toNot(beNil())
+                    expect(storedData).to(equal(testData))
+                }
+
+                it("can set a string value to nil") {
+                    _ = keychain.putString(testKey, value: nil, accessibleAttribute: .WhenUnlockedThisDeviceOnly)
+
+                    let storedString = keychain.getString(testKey, accessibleAttribute: .WhenUnlockedThisDeviceOnly)
+                    expect(storedString).to(beNil())
+                }
+
+                it("can set a data value to nil") {
+                    _ = keychain.putString(testKey, value: nil, accessibleAttribute: .WhenUnlockedThisDeviceOnly)
+
+                    let storedData = keychain.get(testKey, accessibleAttribute: .WhenUnlockedThisDeviceOnly)
+                    expect(storedData).to(beNil())
+                }
+
+                it("can override a value") {
+                    let origString = "exciting stuff?"
+                    let finalString = "boring stuff?"
+
+                    _ = keychain.putString(testKey, value: origString, accessibleAttribute: .WhenUnlockedThisDeviceOnly)
+                    let storedOrigString = keychain.getString(testKey, accessibleAttribute: .WhenUnlockedThisDeviceOnly)
+                    expect(storedOrigString).to(equal(origString))
+
+                    _ = keychain.putString(testKey, value: finalString, accessibleAttribute: .WhenUnlockedThisDeviceOnly)
+                    let storedFinalString = keychain.getString(testKey, accessibleAttribute: .WhenUnlockedThisDeviceOnly)
+                    expect(storedFinalString).to(equal(finalString))
+                }
+
+                it("can delete a value") {
+                    let testString = "exciting stuff?"
+                    _ = keychain.putString(testKey, value: testString, accessibleAttribute: .WhenUnlockedThisDeviceOnly)
+                    let storedString = keychain.getString(testKey, accessibleAttribute: .WhenUnlockedThisDeviceOnly)
+                    _ = keychain.putString(testKey, value: nil, accessibleAttribute: .WhenUnlockedThisDeviceOnly)
+
+                    let storedNil = keychain.getString(testKey, accessibleAttribute: .WhenUnlockedThisDeviceOnly)
+                    expect(storedString).to(equal(testString))
+                    expect(storedNil).to(beNil())
+                }
+
+                it("can delete all keys and data for the app") {
+                    // Push in a key/data element and verify it exists
+                    let testString = "exciting stuff?"
+                    _ = keychain.putString(testKey, value: testString, accessibleAttribute: .WhenUnlockedThisDeviceOnly)
+                    var storedString = keychain.getString(testKey, accessibleAttribute: .WhenUnlockedThisDeviceOnly)
+                    expect(storedString).to(equal(testString))
+
+                    // Delete everything and then verify you can't access the key/data any more
+                    let status = keychain.deleteAllKeysAndDataForApp()
+                    expect(status).to(beTrue())
+                    storedString = keychain.getString(testKey, accessibleAttribute: .WhenUnlockedThisDeviceOnly)
+                    expect(storedString).to(beNil())
+                }
+
+                it("can't access a key from a different account") {
+                    testKey = "SuperSecretKey"
+                    let testString = "you can't see me"
+
+                    // Push in a key/data element and verify it exists in the main account
+                    _ = keychain.putString(testKey, value: testString, accessibleAttribute: .WhenUnlockedThisDeviceOnly)
+                    var storedString = keychain.getString(testKey, accessibleAttribute: .WhenUnlockedThisDeviceOnly)
+                    expect(storedString).to(equal(testString))
+                    
+                    // Try to gain access to a key from another account
+                    let otherKeychain = KeychainAccess(account: "SomeOtherAccount@RobotsAndPencils.com")
+                    storedString = otherKeychain.getString(testKey, accessibleAttribute: .WhenUnlockedThisDeviceOnly)
+                    expect(storedString).to(beNil())
+                }
             }
-
-            it("can delete a value") {
-                let testString = "exciting stuff?"
-                _ = keychain.putString(testKey, value: testString)
-                let storedString = keychain.getString(testKey)
-                _ = keychain.putString(testKey, value: nil)
-                
-                let storedNil = keychain.getString(testKey)
-                expect(storedString).to(equal(testString))
-                expect(storedNil).to(beNil())
-            }
-
-            it("can delete all keys and data for the app") {
-                // Push in a key/data element and verify it exists
-                let testString = "exciting stuff?"
-                _ = keychain.putString(testKey, value: testString)
-                var storedString = keychain.getString(testKey)
-                expect(storedString).to(equal(testString))
-
-                // Delete everything and then verify you can't access the key/data any more
-                let status = keychain.deleteAllKeysAndDataForApp()
-                expect(status).to(beTrue())
-                storedString = keychain.getString(testKey)
-                expect(storedString).to(beNil())
-            }
-
-            it("can't access a key from a different account") {
-                testKey = "SuperSecretKey"
-                let testString = "you can't see me"
-
-                // Push in a key/data element and verify it exists in the main account
-                _ = keychain.putString(testKey, value: testString)
-                var storedString = keychain.getString(testKey)
-                expect(storedString).to(equal(testString))
-                
-                // Try to gain access to a key from another account
-                let otherKeychain = KeychainAccess(account: "SomeOtherAccount@RobotsAndPencils.com")
-                storedString = otherKeychain.getString(testKey)
-                expect(storedString).to(beNil())
-            }
-
         }
 
         describe("A KeychainAccessibleAttribute") {

--- a/AstroTests/Unit Tests/Security/KeychainAccessSpec.swift
+++ b/AstroTests/Unit Tests/Security/KeychainAccessSpec.swift
@@ -142,6 +142,58 @@ class KeychainAccessSpec: QuickSpec {
             }
 
         }
+
+        describe("A KeychainAccessibleAttribute") {
+
+            context("when unlocked") {
+                let attribute = KeychainAccessibleAttribute.WhenUnlocked
+                it("should return kSecAttrAccessibleWhenUnlocked") {
+                    expect(String(attribute.secAttrValue())).to(equal(String(kSecAttrAccessibleWhenUnlocked)))
+                }
+            }
+
+            context("when after first unlock") {
+                let attribute = KeychainAccessibleAttribute.AfterFirstUnlock
+                it("should return kSecAttrAccessibleAfterFirstUnlock") {
+                    expect(String(attribute.secAttrValue())).to(equal(String(kSecAttrAccessibleAfterFirstUnlock)))
+                }
+            }
+
+            context("when always") {
+                let attribute = KeychainAccessibleAttribute.Always
+                it("should return kSecAttrAccessibleAlways") {
+                    expect(String(attribute.secAttrValue())).to(equal(String(kSecAttrAccessibleAlways)))
+                }
+            }
+
+            context("when passcode set this device only") {
+                let attribute = KeychainAccessibleAttribute.WhenPasscodeSetThisDeviceOnly
+                it("should return kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly") {
+                    expect(String(attribute.secAttrValue())).to(equal(String(kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly)))
+                }
+            }
+
+            context("when unlocked this device only") {
+                let attribute = KeychainAccessibleAttribute.WhenUnlockedThisDeviceOnly
+                it("should return kSecAttrAccessibleWhenUnlockedThisDeviceOnly") {
+                    expect(String(attribute.secAttrValue())).to(equal(String(kSecAttrAccessibleWhenUnlockedThisDeviceOnly)))
+                }
+            }
+
+            context("when after first unlock this device only") {
+                let attribute = KeychainAccessibleAttribute.AfterFirstUnlockThisDeviceOnly
+                it("should return kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly") {
+                    expect(String(attribute.secAttrValue())).to(equal(String(kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly)))
+                }
+            }
+
+            context("when always this device only") {
+                let attribute = KeychainAccessibleAttribute.AlwaysThisDeviceOnly
+                it("should return kSecAttrAccessibleAlwaysThisDeviceOnly") {
+                    expect(String(attribute.secAttrValue())).to(equal(String(kSecAttrAccessibleAlwaysThisDeviceOnly)))
+                }
+            }
+        }
     }
     
 }

--- a/AstroTests/Unit Tests/Security/KeychainAccessSpec.swift
+++ b/AstroTests/Unit Tests/Security/KeychainAccessSpec.swift
@@ -16,17 +16,13 @@ import Nimble
 class KeychainAccessSpec: QuickSpec {
     
     override func spec() {
-        
-    /**
-     NOTE: Unit tests will fail for the KeychainAccessSpec due to the an issue around Keychain entitlements (https://forums.developer.apple.com/thread/51071).
-     Radar's have been filed by the looks of it so now its just a waiting game until those tests will clear.
-         
+
         describe("A keychain") {
             let keychain = KeychainAccess(account: "Test@RobotsAndPencils.com")
             var testKey = "AccessKey"
             
             afterEach {
-                keychain.delete(testKey)
+                _ = keychain.delete(testKey)
             }
             
             it("returns nil for retrieving a key that doesn't exist") {
@@ -36,7 +32,7 @@ class KeychainAccessSpec: QuickSpec {
 
             it("can store and retrieve a string") {
                 let testString = "something really boring"
-                keychain.putString(testKey, value: testString)
+                _ = keychain.putString(testKey, value: testString)
                 
                 let storedString = keychain.getString(testKey)
                 expect(storedString).to(equal(testString))
@@ -44,12 +40,12 @@ class KeychainAccessSpec: QuickSpec {
             
             it("can store and retrieve data") {
                 testKey = "DataKey"
-                guard let testFilePath = NSBundle(forClass: KeychainAccessSpec.self).pathForResource("testdata", ofType: "json") else {
+                guard let testFilePath = Bundle(for: KeychainAccessSpec.self).url(forResource: "testdata", withExtension: "json") else {
                     fail("no test file")
                     return
                 }
-                let testData = NSData(contentsOfFile: testFilePath)
-                keychain.put(testKey, data: testData)
+                let testData = try! Data(contentsOf: testFilePath)
+                _ = keychain.put(testKey, data: testData)
                 
                 let storedData = keychain.get(testKey)
                 expect(storedData).toNot(beNil())
@@ -57,14 +53,14 @@ class KeychainAccessSpec: QuickSpec {
             }
             
             it("can set a string value to nil") {
-                keychain.putString(testKey, value: nil)
+                _ = keychain.putString(testKey, value: nil)
                 
                 let storedString = keychain.getString(testKey)
                 expect(storedString).to(beNil())
             }
             
             it("can set a data value to nil") {
-                keychain.putString(testKey, value: nil)
+                _ = keychain.putString(testKey, value: nil)
                 
                 let storedData = keychain.get(testKey)
                 expect(storedData).to(beNil())
@@ -80,11 +76,11 @@ class KeychainAccessSpec: QuickSpec {
             
             it("can be accessed using subscripting for data") {
                 testKey = "DataKey"
-                guard let testFilePath = NSBundle(forClass: KeychainAccessSpec.self).pathForResource("testdata", ofType: "json") else {
+                guard let testFilePath = Bundle(for: KeychainAccessSpec.self).url(forResource: "testdata", withExtension: "json") else {
                     fail("no test file")
                     return
                 }
-                let testData = NSData(contentsOfFile: testFilePath)
+                let testData = try! Data(contentsOf: testFilePath)
                 keychain[data: testKey] = testData
                 
                 let storedData = keychain[data: testKey]
@@ -96,20 +92,20 @@ class KeychainAccessSpec: QuickSpec {
                 let origString = "exciting stuff?"
                 let finalString = "boring stuff?"
 
-                keychain.putString(testKey, value: origString)
+                _ = keychain.putString(testKey, value: origString)
                 let storedOrigString = keychain.getString(testKey)
                 expect(storedOrigString).to(equal(origString))
                 
-                keychain.putString(testKey, value: finalString)
+                _ = keychain.putString(testKey, value: finalString)
                 let storedFinalString = keychain.getString(testKey)
                 expect(storedFinalString).to(equal(finalString))
             }
 
             it("can delete a value") {
                 let testString = "exciting stuff?"
-                keychain.putString(testKey, value: testString)
+                _ = keychain.putString(testKey, value: testString)
                 let storedString = keychain.getString(testKey)
-                keychain.putString(testKey, value: nil)
+                _ = keychain.putString(testKey, value: nil)
                 
                 let storedNil = keychain.getString(testKey)
                 expect(storedString).to(equal(testString))
@@ -119,7 +115,7 @@ class KeychainAccessSpec: QuickSpec {
             it("can delete all keys and data for the app") {
                 // Push in a key/data element and verify it exists
                 let testString = "exciting stuff?"
-                keychain.putString(testKey, value: testString)
+                _ = keychain.putString(testKey, value: testString)
                 var storedString = keychain.getString(testKey)
                 expect(storedString).to(equal(testString))
 
@@ -135,7 +131,7 @@ class KeychainAccessSpec: QuickSpec {
                 let testString = "you can't see me"
 
                 // Push in a key/data element and verify it exists in the main account
-                keychain.putString(testKey, value: testString)
+                _ = keychain.putString(testKey, value: testString)
                 var storedString = keychain.getString(testKey)
                 expect(storedString).to(equal(testString))
                 
@@ -146,8 +142,6 @@ class KeychainAccessSpec: QuickSpec {
             }
 
         }
-        
-    */
     }
     
 }


### PR DESCRIPTION
Hey guys, you might not know me, but I've been working with @aerickson14. Doing this PR to support some security issues we need to address.

Sometimes when you want to set keychain values, you want to set how that item will behave. Whether it's just on that device, or whether a passcode has been set on that device.

This PR does that, mirroring the `kSecAttrAccessible` set of values. Providing a easier-on-the-eye API.

There won't be any breaking changes for the API here as there are default values for all the `open` methods.

Tests are updated and renabled. They work on Xcode8.3, but may fail on the CI, as there was a comment saying they were causing problems.