### PR TITLE
Fix Xcode 8.3 warnings

### DIFF
--- a/Astro/Security/KeychainAccess.swift
+++ b/Astro/Security/KeychainAccess.swift
@@ -49,7 +49,7 @@ open class KeychainAccess {
         guard let data = self.get(key) else {
             return nil
         }
-        return NSString(data: data, encoding: String.Encoding.utf8.rawValue) as? String
+        return NSString(data: data, encoding: String.Encoding.utf8.rawValue) as String?
     }
     
     /**
@@ -128,7 +128,7 @@ open class KeychainAccess {
             if status == errSecSuccess {
                 return true
             }
-            Log.debug("Failed to add data to keychain with status=\(status). Attempted to add data [\(data)] for key [\(key)]")
+            Log.debug("Failed to add data to keychain with status=\(status). Attempted to add data [\(String(describing: data))] for key [\(key)]")
             return false
         } else {
             Log.debug("Failed to add key to keychain with status=\(status). Attempted to add key [\(key)]")


### PR DESCRIPTION
This simply fixes 2 warnings you get when compiling with Xcode 8.3 and Swift 3.1