### PR TITLE
Refine ReusableView protocol

### DIFF
--- a/Astro.xcodeproj/project.pbxproj
+++ b/Astro.xcodeproj/project.pbxproj
@@ -23,8 +23,11 @@
 		B69726CE1BD9162F0047EEB9 /* LoggerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69726CD1BD9162F0047EEB9 /* LoggerSpec.swift */; };
 		BD62EA481C929BF0004A02DF /* EnumCountable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD62EA471C929BF0004A02DF /* EnumCountable.swift */; };
 		BD62EA4B1C929C1C004A02DF /* EnumCountableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD62EA4A1C929C1C004A02DF /* EnumCountableSpec.swift */; };
+		CA1EF8AF2182AA7400554392 /* IdentifiableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1EF8AE2182AA7400554392 /* IdentifiableType.swift */; };
 		CA5380CB1C5C195900204A68 /* UIColor+AstroGadgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5380CA1C5C195900204A68 /* UIColor+AstroGadgets.swift */; };
 		CA5380CD1C5C196E00204A68 /* UIColor+AstroGadgetsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5380CC1C5C196E00204A68 /* UIColor+AstroGadgetsSpec.swift */; };
+		CAB40CD1215313F5008CBE6B /* UIStoryboard+AstroGadgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB40CD0215313F5008CBE6B /* UIStoryboard+AstroGadgets.swift */; };
+		CAB40CD32153149F008CBE6B /* MKMapView+AstroGadgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB40CD22153149F008CBE6B /* MKMapView+AstroGadgets.swift */; };
 		D0C3176529877E28CFD27E77 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C31A257874127AD224738D /* Log.swift */; };
 		D6F831A48F327D5367262464 /* Pods_AstroTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D24B772E4EC6454D9C2C893 /* Pods_AstroTests.framework */; };
 		E62F9D1C1D62264F005402BF /* UICollectionView+AstroGadgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62F9D1B1D62264F005402BF /* UICollectionView+AstroGadgets.swift */; };
@@ -71,8 +74,11 @@
 		BD62EA471C929BF0004A02DF /* EnumCountable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EnumCountable.swift; path = Utils/EnumCountable.swift; sourceTree = "<group>"; };
 		BD62EA4A1C929C1C004A02DF /* EnumCountableSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumCountableSpec.swift; sourceTree = "<group>"; };
 		BD95704572604E86D00F715F /* Pods-Astro.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Astro.release.xcconfig"; path = "Pods/Target Support Files/Pods-Astro/Pods-Astro.release.xcconfig"; sourceTree = "<group>"; };
+		CA1EF8AE2182AA7400554392 /* IdentifiableType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifiableType.swift; sourceTree = "<group>"; };
 		CA5380CA1C5C195900204A68 /* UIColor+AstroGadgets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+AstroGadgets.swift"; sourceTree = "<group>"; };
 		CA5380CC1C5C196E00204A68 /* UIColor+AstroGadgetsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+AstroGadgetsSpec.swift"; sourceTree = "<group>"; };
+		CAB40CD0215313F5008CBE6B /* UIStoryboard+AstroGadgets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStoryboard+AstroGadgets.swift"; sourceTree = "<group>"; };
+		CAB40CD22153149F008CBE6B /* MKMapView+AstroGadgets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MKMapView+AstroGadgets.swift"; sourceTree = "<group>"; };
 		D0C31A257874127AD224738D /* Log.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
 		D5D8E2A7279FA75989658B29 /* Pods-Astro.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Astro.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Astro/Pods-Astro.debug.xcconfig"; sourceTree = "<group>"; };
 		E62F9D1B1D62264F005402BF /* UICollectionView+AstroGadgets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UICollectionView+AstroGadgets.swift"; sourceTree = "<group>"; };
@@ -112,7 +118,10 @@
 				E62F9D1B1D62264F005402BF /* UICollectionView+AstroGadgets.swift */,
 				E62F9D1D1D6227DE005402BF /* UITableView+AstroGadgets.swift */,
 				2E9348D0FB90D68FC7E5C3D7 /* UIViewController+AstroGadgets.swift */,
+				CAB40CD0215313F5008CBE6B /* UIStoryboard+AstroGadgets.swift */,
+				CAB40CD22153149F008CBE6B /* MKMapView+AstroGadgets.swift */,
 				535DF1091C87864E00961785 /* LayoutLabel.swift */,
+				CA1EF8AE2182AA7400554392 /* IdentifiableType.swift */,
 				E6D5F8831D35B55600CB4D5F /* ReusableView.swift */,
 				E665B02A1D35BB4B0099C89E /* NibLoadableView.swift */,
 			);
@@ -454,7 +463,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				BD62EA481C929BF0004A02DF /* EnumCountable.swift in Sources */,
+				CAB40CD32153149F008CBE6B /* MKMapView+AstroGadgets.swift in Sources */,
 				535DF10A1C87864E00961785 /* LayoutLabel.swift in Sources */,
+				CA1EF8AF2182AA7400554392 /* IdentifiableType.swift in Sources */,
+				CAB40CD1215313F5008CBE6B /* UIStoryboard+AstroGadgets.swift in Sources */,
 				E6D5F8841D35B55600CB4D5F /* ReusableView.swift in Sources */,
 				2E9345EE0AEB18FB859A8D06 /* UIView+AstroGadgets.swift in Sources */,
 				2E934B8A416AF015C76347DC /* UIViewController+AstroGadgets.swift in Sources */,

--- a/Astro/UI/IdentifiableType.swift
+++ b/Astro/UI/IdentifiableType.swift
@@ -1,4 +1,4 @@
-//  Copyright © 2016 Robots and Pencils, Inc. All rights reserved.
+//  Copyright © 2018 Robots and Pencils, Inc. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 //
@@ -10,36 +10,24 @@
 //
 
 import UIKit
-import MapKit
-
-// MARK: - Reusable
 
 /**
- Has a reuse identifier appropriate for APIs that reuse conforming instances
+ Has an identifier for its type. Useful when an identifier is needed for
+ view instantiation, reuse, or registration, but not limited to use by UI code.
+
+ Note that this is different from an _instance's_ identifier.
  */
-public protocol ReusableView: IdentifiableType {
+public protocol IdentifiableType {
     /**
-     The default value is the type's identifier but can be overriden
+     The default value is the type's name but can be overriden
      */
-    static var reuseIdentifier: String { get }
+    static var identifier: String { get }
 }
 
-public extension ReusableView {
-    static var reuseIdentifier: String {
-        return identifier
+public extension IdentifiableType {
+    static var identifier: String {
+        return String(describing: self)
     }
 }
 
-extension UITableViewHeaderFooterView: ReusableView {}
-extension UICollectionReusableView: ReusableView {}
-extension MKAnnotationView: ReusableView {}
-
-// MARK: - ReusableCell
-
-/**
- Has a reuse identifier
- */
-public protocol ReusableCell: ReusableView {}
-
-extension UITableViewCell: ReusableCell {}
-extension UICollectionViewCell: ReusableCell {}
+extension UIViewController: IdentifiableType {}

--- a/Astro/UI/MKMapView+AstroGadgets.swift
+++ b/Astro/UI/MKMapView+AstroGadgets.swift
@@ -1,0 +1,51 @@
+//  Copyright © 2018 Robots and Pencils, Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+//  Neither the name of the Robots and Pencils, Inc. nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+//
+//  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import MapKit
+
+extension MKMapView {
+    /**
+     Registers annotation view based on its reuse identifier
+
+    - parameter type:  The annotation view type
+    */
+    @available(iOS 11.0, *)
+    public func registerView<View: MKAnnotationView>(ofType type: View.Type) {
+        register(type.self, forAnnotationViewWithReuseIdentifier: type.reuseIdentifier)
+    }
+
+    /**
+     Dequeue an annotation view that is registered with its own reuse identifier
+
+     - parameter type:  The annotation view type
+     */
+    func dequeueReusableAnnotationView<View: MKAnnotationView>(ofType type: View.Type) -> View {
+        guard let view = dequeueReusableAnnotationView(withIdentifier: type.reuseIdentifier) as? View else {
+            fatalError("Could not dequeue table view cell with identifier: \(type.reuseIdentifier)")
+        }
+        return view
+    }
+
+    /**
+     Dequeue an annotation view that is registered with its own reuse
+     identifier, for a particular type of annotation
+
+     - parameter type:  The annotation view type
+     - parameter type:  The annotation type, which conforms to IdentifiableType
+     */
+    @available(iOS 11.0, *)
+    func dequeueReusableAnnotationView<View: MKAnnotationView, Annotation: MKAnnotation & IdentifiableType>(ofType type: View.Type, for annotation: Annotation) -> View {
+        guard let view = dequeueReusableAnnotationView(withIdentifier: type.reuseIdentifier, for: annotation) as? View else {
+            fatalError("Could not dequeue annotation view with identifier: \(type.reuseIdentifier)")
+        }
+        return view
+    }
+}

--- a/Astro/UI/NibLoadableView.swift
+++ b/Astro/UI/NibLoadableView.swift
@@ -20,7 +20,7 @@ import UIKit
  every nib file. Much of this is based off of the ideas from:
  https://medium.com/@gonzalezreal/ios-cell-registration-reusing-with-swift-protocol-extensions-and-generics-c5ac4fb5b75e
  */
-public protocol NibLoadableView: class {
+public protocol NibLoadableView: IdentifiableType {
     static var nibName: String { get }
 }
 
@@ -30,6 +30,12 @@ public protocol NibLoadableView: class {
  */
 public extension NibLoadableView where Self: UIView {
     static var nibName: String {
-        return String(describing: Self.self)
+        return identifier
+    }
+
+    static var nib: UINib {
+        let bundle = Bundle(for: self)
+        let nib = UINib(nibName: nibName, bundle: bundle)
+        return nib
     }
 }

--- a/Astro/UI/UICollectionView+AstroGadgets.swift
+++ b/Astro/UI/UICollectionView+AstroGadgets.swift
@@ -18,22 +18,32 @@ public extension UICollectionView {
     /**
      Registration method for subclasses implementing only ReusableView
      
-     - parameter cellType: The cell subclass type that conforms to the ReusableView protocol
+     - parameter type: The cell subclass type that conforms to the ReusableView
+     protocol
      */
-    public func register<T: UICollectionViewCell>(_ cellType: T.Type) where T: ReusableView {
-        register(cellType.self, forCellWithReuseIdentifier: cellType.defaultReuseIdentifier)
+    public func registerCell<Cell: UICollectionViewCell>(ofType type: Cell.Type) {
+        register(type, forCellWithReuseIdentifier: type.reuseIdentifier)
     }
     
     /**
      Registration method for subclasses implementing both ReusableView and
      NibLoadableView
      
-     - parameter cellType: The cell subclass type that conforms to both ReusableView and NibLoadableView protocols
+     - parameter type: The cell subclass type that conforms to both ReusableView
+     and NibLoadableView protocols
      */
-    public func register<T: UICollectionViewCell>(_ cellType: T.Type) where T: ReusableView, T: NibLoadableView {
-        let bundle = Bundle(for: cellType.self)
-        let nib = UINib(nibName: cellType.nibName, bundle: bundle)
-        register(nib, forCellWithReuseIdentifier: cellType.defaultReuseIdentifier)
+    public func registerCell<Cell: UICollectionViewCell>(ofType type: Cell.Type) where Cell: NibLoadableView {
+        register(type.nib, forCellWithReuseIdentifier: type.reuseIdentifier)
+    }
+
+    /**
+     Registers a UICollectionReusableView subclass for use in creating supplementary views for the collection view.
+
+     - parameter kind: The kind of supplementary view to retrieve
+     - parameter type: The UICollectionReusableView subclass type to register
+     */
+    public func registerReusableSupplementaryView<View: UICollectionReusableView>(ofKind kind: String, type: View.Type) {
+        register(type, forSupplementaryViewOfKind: kind, withReuseIdentifier: type.identifier)
     }
     
     /**
@@ -41,12 +51,30 @@ public extension UICollectionView {
      ReusableView – a nice detail is that it accepts a type, rather than reuse
      identifier
      
+     - parameter type: The cell subclass type that conforms to the ReusableView
+     protocol
      - parameter indexPath: The index path of the cell to dequeue
      */
-    public func dequeueReusableCell<T: UICollectionViewCell>(forIndexPath indexPath: IndexPath) -> T where T: ReusableView {
-        guard let cell = self.dequeueReusableCell(withReuseIdentifier: T.defaultReuseIdentifier, for: indexPath) as? T else {
-            fatalError("Could not dequeue collection view cell with identifier: \(T.defaultReuseIdentifier)")
+    public func dequeueReusableCell<Cell: UICollectionViewCell>(ofType type: Cell.Type, for indexPath: IndexPath) -> Cell {
+        guard let cell = dequeueReusableCell(withReuseIdentifier: type.reuseIdentifier, for: indexPath) as? Cell else {
+            fatalError("Could not dequeue collection view cell with identifier: \(type.reuseIdentifier)")
         }
         return cell
+    }
+
+    /**
+     Ideal dequeueing method for reusable supplementary views which conform to
+     ReusableView – a nice detail is that it accepts a type, rather than reuse
+     identifier
+
+     - parameter kind: The kind of supplementary view to retrieve
+     - parameter type: The UICollectionReusableView subclass type to retrieve
+     - parameter indexPath: The index path specifying the location of the supplementary view in the collection view
+     */
+    public func dequeueReusableSupplementaryView<View: UICollectionReusableView>(ofKind kind: String, type: View.Type, for indexPath: IndexPath) -> View {
+        guard let view = dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: type.identifier, for: indexPath) as? View else {
+            fatalError("Could not dequeue supplementary view with identifier: \(type.identifier)")
+        }
+        return view
     }
 }

--- a/Astro/UI/UIStoryboard+AstroGadgets.swift
+++ b/Astro/UI/UIStoryboard+AstroGadgets.swift
@@ -1,4 +1,4 @@
-//  Copyright © 2016 Robots and Pencils, Inc. All rights reserved.
+//  Copyright © 2018 Robots and Pencils, Inc. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 //
@@ -10,36 +10,17 @@
 //
 
 import UIKit
-import MapKit
 
-// MARK: - Reusable
-
-/**
- Has a reuse identifier appropriate for APIs that reuse conforming instances
- */
-public protocol ReusableView: IdentifiableType {
+public extension UIStoryboard {
     /**
-     The default value is the type's identifier but can be overriden
-     */
-    static var reuseIdentifier: String { get }
-}
+     Instantiates a view controller using its type's identifier
 
-public extension ReusableView {
-    static var reuseIdentifier: String {
-        return identifier
+     - parameter type:  The view controller type
+     */
+    func instantiateView<View: UIViewController>(ofType type: View.Type) -> View {
+        guard let view = instantiateViewController(withIdentifier: type.identifier) as? View else {
+            fatalError("Could not instantiate view with identifier: \(type.identifier)")
+        }
+        return view
     }
 }
-
-extension UITableViewHeaderFooterView: ReusableView {}
-extension UICollectionReusableView: ReusableView {}
-extension MKAnnotationView: ReusableView {}
-
-// MARK: - ReusableCell
-
-/**
- Has a reuse identifier
- */
-public protocol ReusableCell: ReusableView {}
-
-extension UITableViewCell: ReusableCell {}
-extension UICollectionViewCell: ReusableCell {}

--- a/Astro/UI/UITableView+AstroGadgets.swift
+++ b/Astro/UI/UITableView+AstroGadgets.swift
@@ -18,35 +18,73 @@ public extension UITableView {
     /**
      Registration method for subclasses implementing only ReusableView
      
-     - parameter cellType: The cell subclass type that conforms to the ReusableView protocol
+     - parameter type: The cell subclass type that conforms to the ReusableView
+     protocol
      */
-    public func register<T: UITableViewCell>(_ cellType: T.Type) where T: ReusableView {
-        self.register(cellType.self, forCellReuseIdentifier: cellType.defaultReuseIdentifier)
+    public func registerCell<Cell: UITableViewCell>(ofType type: Cell.Type) {
+        register(type.self, forCellReuseIdentifier: type.reuseIdentifier)
     }
     
     /**
      Registration method for subclasses implementing both ReusableView and
      NibLoadableView
      
-     - parameter cellType: The cell subclass type that conforms to both ReusableView and NibLoadableView protocols
+     - parameter type: The cell subclass type that conforms to both ReusableView
+     and NibLoadableView protocols
      */
-    public func register<T: UITableViewCell>(_ cellType: T.Type) where T: ReusableView, T: NibLoadableView {
-        let bundle = Bundle(for: cellType.self)
-        let nib = UINib(nibName: cellType.nibName, bundle: bundle)
-        self.register(nib, forCellReuseIdentifier: cellType.defaultReuseIdentifier)
+    public func registerCell<Cell: UITableViewCell>(ofType type: Cell.Type) where Cell: NibLoadableView {
+        register(type.nib, forCellReuseIdentifier: type.reuseIdentifier)
+    }
+
+    /**
+     Registration method for subclasses implementing only ReusableView
+
+     - parameter type: The cell subclass type that conforms to the ReusableView
+     protocol
+     */
+    func registerHeaderFooterView<View: UITableViewHeaderFooterView>(ofType type: View.Type) {
+        register(type.self, forHeaderFooterViewReuseIdentifier: type.reuseIdentifier)
+    }
+
+    /**
+     Registration method for subclasses implementing both ReusableView and
+     NibLoadableView
+
+     - parameter type: The cell subclass type that conforms to both ReusableView
+     and NibLoadableView protocols
+     */
+    func registerHeaderFooterView<View: UITableViewHeaderFooterView>(ofType type: View.Type) where View: NibLoadableView {
+        register(type.nib, forHeaderFooterViewReuseIdentifier: type.reuseIdentifier)
     }
     
     /**
      Ideal cell dequeueing method for cell subclasses which conform to
      ReusableView – a nice detail is that it accepts a type, rather than reuse
      identifier
-     
+
+     - parameter type:  The cell subclass type that conforms to the ReusableView
+     protocol
      - parameter indexPath: The index path of the cell to dequeue
      */
-    public func dequeueReusableCell<T: UITableViewCell>(forIndexPath indexPath: IndexPath) -> T where T: ReusableView {
-        guard let cell = self.dequeueReusableCell(withIdentifier: T.defaultReuseIdentifier, for: indexPath) as? T else {
-            fatalError("Could not dequeue table view cell with identifier: \(T.defaultReuseIdentifier)")
+    public func dequeueReusableCell<Cell: UITableViewCell>(ofType type: Cell.Type, for indexPath: IndexPath) -> Cell {
+        guard let cell = dequeueReusableCell(withIdentifier: type.reuseIdentifier, for: indexPath) as? Cell else {
+            fatalError("Could not dequeue table view cell with identifier: \(type.reuseIdentifier)")
         }
         return cell
+    }
+
+    /**
+     Ideal dequeueing method for reusable header/footer views which conform to
+     ReusableView – a nice detail is that it accepts a type, rather than reuse
+     identifier
+
+     - parameter type:  The cell subclass type that conforms to the ReusableView
+     protocol
+     */
+    func dequeueReusableHeaderFooterView<View: UITableViewHeaderFooterView>(ofType type: View.Type) -> View {
+        guard let view = self.dequeueReusableHeaderFooterView(withIdentifier: type.reuseIdentifier) as? View else {
+            fatalError("Could not dequeue table header/footer view with identifier: \(type.reuseIdentifier)")
+        }
+        return view
     }
 }

--- a/AstroTests/Unit Tests/UI/ReusableViewSpec.swift
+++ b/AstroTests/Unit Tests/UI/ReusableViewSpec.swift
@@ -13,13 +13,20 @@ import Quick
 import Nimble
 @testable import Astro
 
-class MockReusableCollectionViewCell: UICollectionViewCell, ReusableView {}
+class MockReusableView: UIView, ReusableView {}
+class MockReusableCollectionViewCell: UICollectionViewCell {}
 
 class ReusableViewSpec: QuickSpec {
     override func spec() {
         describe("Given a view subclass conforming to ReusableView") {
             it("should have a default reuse identifier") {
-                expect(MockReusableCollectionViewCell.defaultReuseIdentifier).to(equal("MockReusableCollectionViewCell"))
+                expect(MockReusableView.reuseIdentifier).to(equal("MockReusableView"))
+            }
+        }
+
+        describe("Given a cell subclass conforming to ReusableCell") {
+            it("should have a default reuse identifier") {
+                expect(MockReusableCollectionViewCell.reuseIdentifier).to(equal("MockReusableCollectionViewCell"))
             }
         }
     }

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		C37EADA2AF8C628390815D0A42C2AECD /* Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4722F76749115703C7664712424802BF /* Await.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		C56C765F972E1C734CC90E2D778AD0C8 /* CwlCatchException.m in Sources */ = {isa = PBXBuildFile; fileRef = 466A33694AD202F68760EDC08F2A1DB8 /* CwlCatchException.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		C9976B28F0BDB89E552934A250463D52 /* ContainElementSatisfying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A17A87F5C21829EDCE4E61C23FB3751 /* ContainElementSatisfying.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		CA1EF8B52182B17900554392 /* IdentifiableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1EF8B42182B17900554392 /* IdentifiableType.swift */; };
 		CC6EDE60A73201DABFC98BC7CAC386E3 /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 838725A5D79D138A96E9A58370482809 /* MatcherProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		CF3E1677F05F5A14272D3119E3C873E7 /* BeLessThanOrEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = C02B6A041827B2ED884C92F69B5CF56F /* BeLessThanOrEqual.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		D0BBEAE1167C476BF9C2DBBF18D93046 /* Closures.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADC45A7599E83ACD3CD2BBE6827C89C9 /* Closures.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
@@ -305,6 +306,7 @@
 		C17AEAC624CBC45B34F9BBBAFA121640 /* NMBExpectation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NMBExpectation.swift; path = Sources/Nimble/Adapters/NMBExpectation.swift; sourceTree = "<group>"; };
 		C4B69FB81873213DD473ABAAF073E2A9 /* NSString+C99ExtendedIdentifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSString+C99ExtendedIdentifier.swift"; path = "Sources/Quick/NSString+C99ExtendedIdentifier.swift"; sourceTree = "<group>"; };
 		C5D68583829879B8D40A53C3ABFCC45E /* UIColor+AstroGadgets.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIColor+AstroGadgets.swift"; path = "Astro/UI/UIColor+AstroGadgets.swift"; sourceTree = "<group>"; };
+		CA1EF8B42182B17900554392 /* IdentifiableType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = IdentifiableType.swift; path = Astro/UI/IdentifiableType.swift; sourceTree = "<group>"; };
 		CA4A67144474A12D0CEE78DFEA381F69 /* ReusableView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReusableView.swift; path = Astro/UI/ReusableView.swift; sourceTree = "<group>"; };
 		CA5F841A373F755E79A64CE9F5990F1C /* Pods-AstroTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-AstroTests.release.xcconfig"; sourceTree = "<group>"; };
 		D04405C8EBD220E451B7DDF4756F3DF0 /* Quick-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Quick-dummy.m"; sourceTree = "<group>"; };
@@ -592,6 +594,7 @@
 				30B69A8C01B4ED8799F7414E612F24D0 /* LayoutLabel.swift */,
 				192FCF368E2A9CF535BD38E6602E01A3 /* NibLoadableView.swift */,
 				CA4A67144474A12D0CEE78DFEA381F69 /* ReusableView.swift */,
+				CA1EF8B42182B17900554392 /* IdentifiableType.swift */,
 				61C9B89FD88E48192CBE2095A64324EE /* UICollectionView+AstroGadgets.swift */,
 				C5D68583829879B8D40A53C3ABFCC45E /* UIColor+AstroGadgets.swift */,
 				B87D273F268548077B54072258F4DD39 /* UITableView+AstroGadgets.swift */,
@@ -1030,6 +1033,7 @@
 				344E98D9AF28FEE3AE31A86207B9778B /* KeychainAccess.swift in Sources */,
 				A9619BE06A19AA65498EE467924EE2F6 /* LayoutLabel.swift in Sources */,
 				75F652D8D0EF4A835689F6C9C31764D3 /* Log.swift in Sources */,
+				CA1EF8B52182B17900554392 /* IdentifiableType.swift in Sources */,
 				99F09E5687548D861CEFB9645D261373 /* NibLoadableView.swift in Sources */,
 				BC65707347AD3984D9C7AA5E23F863BA /* Queue.swift in Sources */,
 				AD7BC55EC12599E76E0225D2E263486D /* ReusableView.swift in Sources */,


### PR DESCRIPTION
This creates a base `IdentifiableType` protocol for types with a type-level `identifier`. This is then used by `ReusableView` and `ReusableCell` to provide a default `reuseIdentifier`, and by `NibLoadableView` to determine a `nibName`. I chose the name `IdentifiableType` to leave room for a future unrelated `Identifiable` protocol that is specific to conforming _instances_. `ReusableCell` doesn't have any more requirements than ReusableView, and so although it might seem unnecessary I think it aligns with the difference between views and cells in UIKit and leaves room for, for example, a requirement to implement `prepareForReuse` or provide estimated sizes (🎩 @teressaeid).

I also added more extensions to UIKit to take advantage of these protocols for instantiation, registration and reuse.

I tried to add or update documentation as needed but please give feedback on how it could be more clear or succinct. I didn't add much for unit testing since this felt mostly mechanical but let me know if you think there would be value in them.