### PR TITLE
RFC: Add Change type

### DIFF
--- a/Astro.xcodeproj/project.pbxproj
+++ b/Astro.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		CA5380CD1C5C196E00204A68 /* UIColor+AstroGadgetsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5380CC1C5C196E00204A68 /* UIColor+AstroGadgetsSpec.swift */; };
 		CAB40CD1215313F5008CBE6B /* UIStoryboard+AstroGadgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB40CD0215313F5008CBE6B /* UIStoryboard+AstroGadgets.swift */; };
 		CAB40CD32153149F008CBE6B /* MKMapView+AstroGadgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB40CD22153149F008CBE6B /* MKMapView+AstroGadgets.swift */; };
+		CAEDCACF21892A600050AF0C /* Change.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAEDCACE21892A600050AF0C /* Change.swift */; };
 		D0C3176529877E28CFD27E77 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C31A257874127AD224738D /* Log.swift */; };
 		D6F831A48F327D5367262464 /* Pods_AstroTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D24B772E4EC6454D9C2C893 /* Pods_AstroTests.framework */; };
 		E62F9D1C1D62264F005402BF /* UICollectionView+AstroGadgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62F9D1B1D62264F005402BF /* UICollectionView+AstroGadgets.swift */; };
@@ -79,6 +80,7 @@
 		CA5380CC1C5C196E00204A68 /* UIColor+AstroGadgetsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+AstroGadgetsSpec.swift"; sourceTree = "<group>"; };
 		CAB40CD0215313F5008CBE6B /* UIStoryboard+AstroGadgets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStoryboard+AstroGadgets.swift"; sourceTree = "<group>"; };
 		CAB40CD22153149F008CBE6B /* MKMapView+AstroGadgets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MKMapView+AstroGadgets.swift"; sourceTree = "<group>"; };
+		CAEDCACE21892A600050AF0C /* Change.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Change.swift; path = Utils/Change.swift; sourceTree = "<group>"; };
 		D0C31A257874127AD224738D /* Log.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
 		D5D8E2A7279FA75989658B29 /* Pods-Astro.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Astro.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Astro/Pods-Astro.debug.xcconfig"; sourceTree = "<group>"; };
 		E62F9D1B1D62264F005402BF /* UICollectionView+AstroGadgets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UICollectionView+AstroGadgets.swift"; sourceTree = "<group>"; };
@@ -224,6 +226,7 @@
 				3F78B54F1CC35D4900A0E30C /* Queue.swift */,
 				BD62EA471C929BF0004A02DF /* EnumCountable.swift */,
 				83593EEFC7D26F39183B2AE1 /* Comparable.swift */,
+				CAEDCACE21892A600050AF0C /* Change.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -478,6 +481,7 @@
 				3F78B5501CC35D4900A0E30C /* Queue.swift in Sources */,
 				CA5380CB1C5C195900204A68 /* UIColor+AstroGadgets.swift in Sources */,
 				835937E4D0DE85A9286BACC6 /* Comparable.swift in Sources */,
+				CAEDCACF21892A600050AF0C /* Change.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Astro/Utils/Change.swift
+++ b/Astro/Utils/Change.swift
@@ -1,0 +1,66 @@
+//  Copyright © 2016 Robots and Pencils, Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+//  Neither the name of the Robots and Pencils, Inc. nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+//
+//  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import Foundation
+
+/**
+ Encapsulates a change between two values of the same type
+
+ Sometimes you need the old and new values of a property in order to perform
+ efficient or pleasing changes elsewhere, like in your UI. This type makes that
+ simpler by allowing you to pass a single value around. It's then possible to
+ get sub-changes with the `change[at: \.value]` subscript.
+
+ ## Example
+
+ ```
+ var model: ViewModel {
+   didSet {
+     let change = Change(old: oldValue, new: model)
+     updateUI(with: change)
+   }
+ }
+
+ func updateUI(with change: Change<Model>) {
+   title = change.new.title
+   updateSomeSubview(with: change[at: \.subviewState])
+   // ...
+ }
+
+ func updateSomeSubview(with change: Change<SubviewState>) {
+   guard change.isDifferent else { return }
+   // ...
+ }
+ ```
+ */
+public struct Change<Value> {
+    public let old: Value
+    public let new: Value
+
+    public init(old: Value, new: Value) {
+        self.old = old
+        self.new = new
+    }
+
+    /**
+     Create a Change between old and new child values at a particular key path
+     */
+    public subscript<ChildValue>(at keyPath: KeyPath<Value, ChildValue>) -> Change<ChildValue> {
+        return Change<ChildValue>(old: old[keyPath: keyPath], new: new[keyPath: keyPath])
+    }
+}
+
+extension Change where Value: Equatable {
+    public var isDifferent: Bool {
+        return old != new
+    }
+}
+

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		C56C765F972E1C734CC90E2D778AD0C8 /* CwlCatchException.m in Sources */ = {isa = PBXBuildFile; fileRef = 466A33694AD202F68760EDC08F2A1DB8 /* CwlCatchException.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		C9976B28F0BDB89E552934A250463D52 /* ContainElementSatisfying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A17A87F5C21829EDCE4E61C23FB3751 /* ContainElementSatisfying.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		CA1EF8B52182B17900554392 /* IdentifiableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1EF8B42182B17900554392 /* IdentifiableType.swift */; };
+		CAEDCAD521892C410050AF0C /* Change.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAEDCAD421892C410050AF0C /* Change.swift */; };
 		CC6EDE60A73201DABFC98BC7CAC386E3 /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 838725A5D79D138A96E9A58370482809 /* MatcherProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		CF3E1677F05F5A14272D3119E3C873E7 /* BeLessThanOrEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = C02B6A041827B2ED884C92F69B5CF56F /* BeLessThanOrEqual.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		D0BBEAE1167C476BF9C2DBBF18D93046 /* Closures.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADC45A7599E83ACD3CD2BBE6827C89C9 /* Closures.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
@@ -309,6 +310,7 @@
 		CA1EF8B42182B17900554392 /* IdentifiableType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = IdentifiableType.swift; path = Astro/UI/IdentifiableType.swift; sourceTree = "<group>"; };
 		CA4A67144474A12D0CEE78DFEA381F69 /* ReusableView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReusableView.swift; path = Astro/UI/ReusableView.swift; sourceTree = "<group>"; };
 		CA5F841A373F755E79A64CE9F5990F1C /* Pods-AstroTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-AstroTests.release.xcconfig"; sourceTree = "<group>"; };
+		CAEDCAD421892C410050AF0C /* Change.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Change.swift; path = Astro/Utils/Change.swift; sourceTree = "<group>"; };
 		D04405C8EBD220E451B7DDF4756F3DF0 /* Quick-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Quick-dummy.m"; sourceTree = "<group>"; };
 		D06396285FFC7F0BD9E17FAD2E374CE4 /* Nimble-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-prefix.pch"; sourceTree = "<group>"; };
 		D16F20B15242D0164137D22DE3C44698 /* Pods-AstroTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-AstroTests-umbrella.h"; sourceTree = "<group>"; };
@@ -643,6 +645,7 @@
 				8AC0B21E88E09373C2FAAAABC6400E1F /* Comparable.swift */,
 				8F1F3DC6EFAEE80A7CD156FDD034FF70 /* EnumCountable.swift */,
 				5B58BA9E5624966B089705BB2EF81137 /* Queue.swift */,
+				CAEDCAD421892C410050AF0C /* Change.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -1039,6 +1042,7 @@
 				AD7BC55EC12599E76E0225D2E263486D /* ReusableView.swift in Sources */,
 				0FE19C62E38ECF161713FE8B04E1D4BA /* UICollectionView+AstroGadgets.swift in Sources */,
 				959935A2C2765497644396E169C0E79A /* UIColor+AstroGadgets.swift in Sources */,
+				CAEDCAD521892C410050AF0C /* Change.swift in Sources */,
 				2EE2A9D98F4BD641EA2B629BAD1A5D9E /* UITableView+AstroGadgets.swift in Sources */,
 				AEFB0F2E4ACCC24B229DCB5476C2DB20 /* UIView+AstroGadgets.swift in Sources */,
 				2ECBEF7EBB0DD63A918F2C9C13013832 /* UIViewController+AstroGadgets.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Astro is a library, built in swift, used to hold common utility methods.
   - [Utils](#utils)
     - [EnumCountable](#enumcountable)
     - [Queue](#queue)
+    - [Change](#change)
 - [Module Management](#module-management)
 - [Contact](#contact)
   - [Maintainers](#maintainers)
@@ -251,6 +252,32 @@ Queue.Background.execute {
     Queue.Main.executeAfter(delay: 1) {
         // Back on main thread
     }
+}
+```
+
+#### Change
+
+`Change<Value>` encapsulates a change between two values of the same type
+
+Sometimes you need the old and new values of a property in order to perform efficient or pleasing changes elsewhere, like in your UI. This type makes that simpler by allowing you to pass a single value around. It's then possible to get sub-changes with the `change[at: \.value]` subscript.
+
+```
+var model: ViewModel {
+    didSet {
+        let change = Change(old: oldValue, new: model)
+        updateUI(with: change)
+    }
+}
+
+func updateUI(with change: Change<Model>) {
+    title = change.new.title
+    updateSomeSubview(with: change[at: \.subviewState])
+    // ...
+}
+
+func updateSomeSubview(with change: Change<SubviewState>) {
+    guard change.isDifferent else { return }
+    // ...
 }
 ```
     


### PR DESCRIPTION
`Change<Value>` encapsulates a change between two values of the same type.

Sometimes you need the old and new values of a property in order to perform efficient or pleasing changes elsewhere, like in your UI. This type makes that simpler by allowing you to pass a single value around. It's then possible to get sub-changes with the `change[at: \.value]` subscript.

On my current project each view controller has its state modelled by a single struct (it's similar to the example code included in the new docs) and adding this type simplified the code a fair bit in some cases and also made it more consistent across the codebase. If you're not modelling views in this way then you might not have a need for a type like this, but perhaps there are other use cases. At least it _seems_ like a fairly general concept.

**Example**

```swift
var state: ViewState {
    didSet {
        let change = Change(old: oldValue, new: state)
        updateUI(with: change)
    }
}

func updateUI(with change: Change<ViewState>) {
    title = change.new.title
    updateSomeSubview(with: change[at: \.subviewState])
    // ...
}

func updateSomeSubview(with change: Change<SubviewState>) {
    guard change.isDifferent else { return }
    // ...
}
```

**Request for feedback**

- The name seems a little odd but I'm not sure of a better option yet. Reading `change.isDifferent`, why would that ever be false? On one hand, it's of course because you can set a property to the exact same value, or have one of its child values be the same. But on the other hand, it reads a little strange until you think about it in that way. If there's a better word for "set of old and new values" or "are the old and new values in a change really not equal" then there might be room for improvement.
- `subscript(at keyPath:)` reads really nicely (`change[at: \.property]`) and might be a little _too cute_, but I don't have a good sense of idiomatic Swift in this case. Before I wrote that I had `func child(at keyPath:)` but `child` is unclear in this context. I'd be open to having both a clearly-named function as well as a subscript that delegated to it. Would love to hear thoughts and examples on this.
- `old` and `new` might not be the _perfect_ words, since a Change could represent a change going back in time (e.g. roll-your-own undo), but they read nicely at the call site in _most_ cases.
- If you have a need for Collection changesets (e.g. https://github.com/osteslag/Changeset), you could add an extension to integrate it with Change:
```swift
import Changeset
extension Change were Value: Collection, Value.Element: Equatable {
    var edits: [Changeset.Edit] {
        return Changeset.edits(from: old, to: new)
    }
}

tableView.update(with: change.edits)
```