### PR TITLE
Extend Comparable with clamp and clamped methods

### DIFF
--- a/Astro/Utils/Comparable.swift
+++ b/Astro/Utils/Comparable.swift
@@ -11,6 +11,25 @@
 
 import Foundation
 
-func clamp<T: Comparable>(_ comparisonValue: T, min minimum: T, max maximum: T) -> T {
-    return max(minimum, min(maximum, comparisonValue))
+extension Comparable {
+    /**
+     Limits the value to the bounds of the given range.
+     */
+    public mutating func clamp(to range: ClosedRange<Self>) {
+        if range.lowerBound > self {
+            self = range.lowerBound
+        }
+        else if range.upperBound < self {
+            self = range.upperBound
+        }
+    }
+
+    /**
+     Returns a copy of this value made by limiting it to the bounds of the given range.
+     */
+    public func clamped(to range: ClosedRange<Self>) -> Self {
+        var clamped = self
+        clamped.clamp(to: range)
+        return clamped
+    }
 }

--- a/AstroTests/Unit Tests/Utils/ComparableSpec.swift
+++ b/AstroTests/Unit Tests/Utils/ComparableSpec.swift
@@ -18,31 +18,69 @@ class ComparableSpec: QuickSpec {
         describe("clamp") {
             context("x is less than min") {
                 it("returns min") {
-                    let result = clamp(0, min: 5, max: 10)
+                    var result = 0
+                    result.clamp(to: 5...10)
                     expect(result).to(equal(5))
                 }
             }
             context("x is equal to min") {
                 it("returns min") {
-                    let result = clamp(5, min: 5, max: 10)
+                    var result = 5
+                    result.clamp(to: 5...10)
                     expect(result).to(equal(5))
                 }
             }
             context("x is between min and max") {
                 it("returns x") {
-                    let result = clamp(5, min: 0, max: 10)
+                    var result = 5
+                    result.clamp(to: 0...10)
                     expect(result).to(equal(5))
                 }
             }
             context("x is equal to max") {
                 it("returns max") {
-                    let result = clamp(10, min: 5, max: 10)
+                    var result = 10
+                    result.clamp(to: 5...10)
                     expect(result).to(equal(10))
                 }
             }
             context("x is greater than max") {
                 it("returns max") {
-                    let result = clamp(10, min: 0, max: 5)
+                    var result = 10
+                    result.clamp(to: 0...5)
+                    expect(result).to(equal(5))
+                }
+            }
+        }
+
+        describe("clamped") {
+            context("x is less than min") {
+                it("returns min") {
+                    let result = 0.clamped(to: 5...10)
+                    expect(result).to(equal(5))
+                }
+            }
+            context("x is equal to min") {
+                it("returns min") {
+                    let result = 5.clamped(to: 5...10)
+                    expect(result).to(equal(5))
+                }
+            }
+            context("x is between min and max") {
+                it("returns x") {
+                    let result = 5.clamped(to: 0...10)
+                    expect(result).to(equal(5))
+                }
+            }
+            context("x is equal to max") {
+                it("returns max") {
+                    let result = 10.clamped(to: 5...10)
+                    expect(result).to(equal(10))
+                }
+            }
+            context("x is greater than max") {
+                it("returns max") {
+                    let result = 10.clamped(to: 0...5)
                     expect(result).to(equal(5))
                 }
             }


### PR DESCRIPTION
The existing free clamp function was useful, but didn't read as nicely as instance methods on Comparable do.

This change adds mutating and non-mutating instance methods. Instead of taking min and max values they now take ClosedRanges which encapsulate lower and upper bounds.

This would normally be a breaking change because of the removal of the free clamp function, but it turns out that it was never made public... So this ends up being purely additive.

See included tests for example usage.