### PR TITLE
Add Sequence extension with overloads taking KeyPaths

### DIFF
--- a/Astro.xcodeproj/project.pbxproj
+++ b/Astro.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		CAB40CD1215313F5008CBE6B /* UIStoryboard+AstroGadgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB40CD0215313F5008CBE6B /* UIStoryboard+AstroGadgets.swift */; };
 		CAB40CD32153149F008CBE6B /* MKMapView+AstroGadgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB40CD22153149F008CBE6B /* MKMapView+AstroGadgets.swift */; };
 		CAEDCACF21892A600050AF0C /* Change.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAEDCACE21892A600050AF0C /* Change.swift */; };
+		CA663428219A55C400C90ECE /* Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA663427219A55C400C90ECE /* Sequence.swift */; };
+		CA66342E219A5C6E00C90ECE /* SequenceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA66342D219A5C6E00C90ECE /* SequenceSpec.swift */; };
 		D0C3176529877E28CFD27E77 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C31A257874127AD224738D /* Log.swift */; };
 		D6F831A48F327D5367262464 /* Pods_AstroTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D24B772E4EC6454D9C2C893 /* Pods_AstroTests.framework */; };
 		E62F9D1C1D62264F005402BF /* UICollectionView+AstroGadgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62F9D1B1D62264F005402BF /* UICollectionView+AstroGadgets.swift */; };
@@ -81,6 +83,8 @@
 		CAB40CD0215313F5008CBE6B /* UIStoryboard+AstroGadgets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStoryboard+AstroGadgets.swift"; sourceTree = "<group>"; };
 		CAB40CD22153149F008CBE6B /* MKMapView+AstroGadgets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MKMapView+AstroGadgets.swift"; sourceTree = "<group>"; };
 		CAEDCACE21892A600050AF0C /* Change.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Change.swift; path = Utils/Change.swift; sourceTree = "<group>"; };
+		CA663427219A55C400C90ECE /* Sequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Sequence.swift; path = Utils/Sequence.swift; sourceTree = "<group>"; };
+		CA66342D219A5C6E00C90ECE /* SequenceSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequenceSpec.swift; sourceTree = "<group>"; };
 		D0C31A257874127AD224738D /* Log.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
 		D5D8E2A7279FA75989658B29 /* Pods-Astro.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Astro.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Astro/Pods-Astro.debug.xcconfig"; sourceTree = "<group>"; };
 		E62F9D1B1D62264F005402BF /* UICollectionView+AstroGadgets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UICollectionView+AstroGadgets.swift"; sourceTree = "<group>"; };
@@ -227,6 +231,7 @@
 				BD62EA471C929BF0004A02DF /* EnumCountable.swift */,
 				83593EEFC7D26F39183B2AE1 /* Comparable.swift */,
 				CAEDCACE21892A600050AF0C /* Change.swift */,
+				CA663427219A55C400C90ECE /* Sequence.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -236,6 +241,7 @@
 			children = (
 				83593E90B43887E2AE664086 /* ComparableSpec.swift */,
 				BD62EA4A1C929C1C004A02DF /* EnumCountableSpec.swift */,
+				CA66342D219A5C6E00C90ECE /* SequenceSpec.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -470,6 +476,7 @@
 				535DF10A1C87864E00961785 /* LayoutLabel.swift in Sources */,
 				CA1EF8AF2182AA7400554392 /* IdentifiableType.swift in Sources */,
 				CAB40CD1215313F5008CBE6B /* UIStoryboard+AstroGadgets.swift in Sources */,
+				CA663428219A55C400C90ECE /* Sequence.swift in Sources */,
 				E6D5F8841D35B55600CB4D5F /* ReusableView.swift in Sources */,
 				2E9345EE0AEB18FB859A8D06 /* UIView+AstroGadgets.swift in Sources */,
 				2E934B8A416AF015C76347DC /* UIViewController+AstroGadgets.swift in Sources */,
@@ -495,6 +502,7 @@
 				63379D811C063BA900DDD95B /* KeychainAccessSpec.swift in Sources */,
 				B69726CE1BD9162F0047EEB9 /* LoggerSpec.swift in Sources */,
 				CA5380CD1C5C196E00204A68 /* UIColor+AstroGadgetsSpec.swift in Sources */,
+				CA66342E219A5C6E00C90ECE /* SequenceSpec.swift in Sources */,
 				2E934D1B02F8932284DCF220 /* UIViewController+AstroGadgetsSpec.swift in Sources */,
 				E62F9D221D623675005402BF /* ReusableViewSpec.swift in Sources */,
 				BD62EA4B1C929C1C004A02DF /* EnumCountableSpec.swift in Sources */,

--- a/Astro/Utils/Sequence.swift
+++ b/Astro/Utils/Sequence.swift
@@ -1,0 +1,97 @@
+//  Copyright © 2018 Robots and Pencils, Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+//  Neither the name of the Robots and Pencils, Inc. nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+//
+//  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import Foundation
+
+public extension Sequence {
+    /**
+     Returns a Boolean value indicating whether the value at the given key path for all elements is true.
+     */
+    public func allSatisfy(_ keyPath: KeyPath<Element, Bool>) -> Bool {
+        return allSatisfy(get(keyPath))
+    }
+
+    /**
+     Returns an array containing the non-nil values at the given key path for each element of this sequence.
+
+     Use this method to receive an array of nonoptional values when the key path's value is optional.
+     */
+    public func compactMap<T>(_ keyPath: KeyPath<Element, T?>) -> [T] {
+        return compactMap(get(keyPath))
+    }
+
+    /**
+     Returns a Boolean value indicating whether the sequence contains an element where the key path's value is true.
+     */
+    public func contains(where keyPath: KeyPath<Element, Bool>) -> Bool {
+        return contains(where: get(keyPath))
+    }
+
+    /**
+     Returns a subsequence by skipping the initial, consecutive elements whose value at the given key path is true.
+     */
+    public func drop(while keyPath: KeyPath<Element, Bool>) -> SubSequence {
+        return drop(while: get(keyPath))
+    }
+
+    /**
+     Returns an array containing, in order, the elements of the sequence with true values at the given key path.
+     */
+    public func filter(_ keyPath: KeyPath<Element, Bool>) -> [Element] {
+        return filter(get(keyPath))
+    }
+
+    /**
+     Returns the first element of the sequence whose value at the given key path is true.
+     */
+    public func first(where keyPath: KeyPath<Element, Bool>) -> Element? {
+        return first(where: get(keyPath))
+    }
+
+    /**
+     Returns an array containing the concatenated values at the given key path for each element of this sequence.
+
+     Use this method to receive a single-level collection when the key path's value type is a sequence or collection for each element.
+     */
+    public func flatMap<S>(_ keyPath: KeyPath<Element, S>) -> [S.Element] where S: Sequence {
+        return flatMap(get(keyPath))
+    }
+
+    /**
+     Returns an array containing the values at the given key path for each element.
+     */
+    public func map<T>(_ keyPath: KeyPath<Element, T>) -> [T] {
+        return map(get(keyPath))
+    }
+
+    /**
+     Returns a subsequence containing the initial, consecutive elements with true values at the given key path.
+     */
+    public func prefix(while keyPath: KeyPath<Element, Bool>) -> SubSequence {
+        return prefix(while: get(keyPath))
+    }
+
+    /**
+     Returns the elements of the sequence, sorted using the < operator on the values at the given key path.
+     */
+    public func sorted<T: Comparable>(by keyPath: KeyPath<Element, T>) -> [Element] {
+        return sorted(by: { first, second in
+            return first[keyPath: keyPath] < second[keyPath: keyPath]
+        })
+    }
+}
+
+/**
+ Converts a KeyPath into the equivalent function
+ */
+func get<Root, Value>(_ keyPath: KeyPath<Root, Value>) -> (Root) -> Value {
+    return { root in root[keyPath: keyPath] }
+}

--- a/AstroTests/Unit Tests/Utils/SequenceSpec.swift
+++ b/AstroTests/Unit Tests/Utils/SequenceSpec.swift
@@ -1,0 +1,143 @@
+//  Copyright © 2018 Robots and Pencils, Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+//  Neither the name of the Robots and Pencils, Inc. nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+//
+//  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import Quick
+import Nimble
+@testable import Astro
+
+class SequenceSpec: QuickSpec {
+    override func spec() {
+        describe("allSatisfy") {
+            it("returns true when all elements' values are true") {
+                expect([
+                    TestElement(id: 0, name: "Zero", isActive: true),
+                    TestElement(id: 1, name: "One", isActive: true)
+                ].allSatisfy(\.isActive))
+                .to(beTrue())
+            }
+
+            it("returns false when not all elements' values are true") {
+                expect([
+                    TestElement(id: 0, name: "Zero", isActive: true),
+                    TestElement(id: 1, name: "One", isActive: false)
+                ].allSatisfy(\.isActive))
+                .to(beFalse())
+            }
+        }
+
+        describe("compactMap") {
+            it("returns all non-nil values") {
+                expect([
+                    TestElement(id: 0, name: "Zero", isActive: true),
+                    TestElement(id: 1, name: nil, isActive: true)
+                ].compactMap(\.name))
+                .to(equal(["Zero"]))
+            }
+        }
+
+        describe("contains") {
+            it("returns true if one element's value is true") {
+                expect([
+                    TestElement(id: 0, name: "Zero", isActive: true),
+                    TestElement(id: 1, name: nil, isActive: false)
+                ].contains(where: \.isActive))
+                .to(beTrue())
+            }
+        }
+
+        describe("drop(while:)") {
+            it("returns subsequence skipping initial true values") {
+                expect([
+                    TestElement(id: 0, name: "Zero", isActive: true),
+                    TestElement(id: 1, name: nil, isActive: false)
+                ].drop(while: \.isActive))
+                .to(equal([TestElement(id: 1, name: nil, isActive: false)]))
+            }
+        }
+
+        describe("filter") {
+            it("returns elements with true values") {
+                expect([
+                    TestElement(id: 0, name: "Zero", isActive: true),
+                    TestElement(id: 1, name: nil, isActive: false)
+                ].filter(\.isActive))
+                .to(equal([TestElement(id: 0, name: "Zero", isActive: true)]))
+            }
+        }
+
+        describe("first(where:)") {
+            it("returns first element with true value") {
+                expect([
+                    TestElement(id: 0, name: "Zero", isActive: false),
+                    TestElement(id: 1, name: "One", isActive: true)
+                ].first(where: \.isActive))
+                .to(equal(TestElement(id: 1, name: "One", isActive: true)))
+            }
+        }
+
+        describe("flatMap") {
+            it("returns concatenated values at key path") {
+                expect([
+                    TestElement(id: 0, name: "Zero", isActive: false, tags: ["Tag1", "Tag2"]),
+                    TestElement(id: 1, name: "One", isActive: true, tags: ["Tag3"])
+                ].flatMap(\.tags))
+                .to(equal(["Tag1", "Tag2", "Tag3"]))
+            }
+        }
+
+        describe("map") {
+            it("returns array of values at key path") {
+                expect([
+                    TestElement(id: 0, name: "Zero", isActive: false),
+                    TestElement(id: 1, name: "One", isActive: true)
+                ].map(\.name))
+                .to(equal(["Zero", "One"]))
+            }
+        }
+
+        describe("prefix(while:)") {
+            it("returns subsequence of elements with true values") {
+                expect([
+                    TestElement(id: 0, name: "Zero", isActive: true),
+                    TestElement(id: 1, name: nil, isActive: false)
+                ].prefix(while: \.isActive))
+                .to(equal([TestElement(id: 0, name: "Zero", isActive: true)]))
+            }
+        }
+
+        describe("sorted(by:)") {
+            it("returns elements sorted by value") {
+                expect([
+                    TestElement(id: 1, name: "One", isActive: true),
+                    TestElement(id: 0, name: "Zero", isActive: true)
+                ].sorted(by: \.id))
+                .to(equal([
+                    TestElement(id: 0, name: "Zero", isActive: true),
+                    TestElement(id: 1, name: "One", isActive: true)
+                ]))
+            }
+        }
+    }
+}
+
+struct TestElement: Equatable {
+    let id: Int
+    let name: String?
+    let isActive: Bool
+    let tags: [String]
+
+    init(id: Int, name: String?, isActive: Bool, tags: [String] = []) {
+        self.id = id
+        self.name = name
+        self.isActive = isActive
+        self.tags = tags
+    }
+}

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		C9976B28F0BDB89E552934A250463D52 /* ContainElementSatisfying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A17A87F5C21829EDCE4E61C23FB3751 /* ContainElementSatisfying.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		CA1EF8B52182B17900554392 /* IdentifiableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1EF8B42182B17900554392 /* IdentifiableType.swift */; };
 		CAEDCAD521892C410050AF0C /* Change.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAEDCAD421892C410050AF0C /* Change.swift */; };
+		CA66342C219A5C5800C90ECE /* Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA66342B219A5C5800C90ECE /* Sequence.swift */; };
 		CC6EDE60A73201DABFC98BC7CAC386E3 /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 838725A5D79D138A96E9A58370482809 /* MatcherProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		CF3E1677F05F5A14272D3119E3C873E7 /* BeLessThanOrEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = C02B6A041827B2ED884C92F69B5CF56F /* BeLessThanOrEqual.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		D0BBEAE1167C476BF9C2DBBF18D93046 /* Closures.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADC45A7599E83ACD3CD2BBE6827C89C9 /* Closures.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
@@ -311,6 +312,7 @@
 		CA4A67144474A12D0CEE78DFEA381F69 /* ReusableView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReusableView.swift; path = Astro/UI/ReusableView.swift; sourceTree = "<group>"; };
 		CA5F841A373F755E79A64CE9F5990F1C /* Pods-AstroTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-AstroTests.release.xcconfig"; sourceTree = "<group>"; };
 		CAEDCAD421892C410050AF0C /* Change.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Change.swift; path = Astro/Utils/Change.swift; sourceTree = "<group>"; };
+		CA66342B219A5C5800C90ECE /* Sequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Sequence.swift; path = Astro/Utils/Sequence.swift; sourceTree = "<group>"; };
 		D04405C8EBD220E451B7DDF4756F3DF0 /* Quick-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Quick-dummy.m"; sourceTree = "<group>"; };
 		D06396285FFC7F0BD9E17FAD2E374CE4 /* Nimble-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-prefix.pch"; sourceTree = "<group>"; };
 		D16F20B15242D0164137D22DE3C44698 /* Pods-AstroTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-AstroTests-umbrella.h"; sourceTree = "<group>"; };
@@ -646,6 +648,7 @@
 				8F1F3DC6EFAEE80A7CD156FDD034FF70 /* EnumCountable.swift */,
 				5B58BA9E5624966B089705BB2EF81137 /* Queue.swift */,
 				CAEDCAD421892C410050AF0C /* Change.swift */,
+				CA66342B219A5C5800C90ECE /* Sequence.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -1039,6 +1042,7 @@
 				CA1EF8B52182B17900554392 /* IdentifiableType.swift in Sources */,
 				99F09E5687548D861CEFB9645D261373 /* NibLoadableView.swift in Sources */,
 				BC65707347AD3984D9C7AA5E23F863BA /* Queue.swift in Sources */,
+				CA66342C219A5C5800C90ECE /* Sequence.swift in Sources */,
 				AD7BC55EC12599E76E0225D2E263486D /* ReusableView.swift in Sources */,
 				0FE19C62E38ECF161713FE8B04E1D4BA /* UICollectionView+AstroGadgets.swift in Sources */,
 				959935A2C2765497644396E169C0E79A /* UIColor+AstroGadgets.swift in Sources */,


### PR DESCRIPTION
Sequence methods that take a mapping function or predicate are often used with a closure that is equivalent to a KeyPath. E.g. `let names = users.map { $0.name }`. It would be better to allow simply `let names = users.map(\.name)`.

The Swift forum contains a few discussions that are relevant:

- https://forums.swift.org/t/pitch-keypath-based-map-flatmap-filter/6266
- https://forums.swift.org/t/treating-a-type-as-a-function/14627/20

But, I want this syntax now :) That being said, we can try to implement this for ourselves with some foresight in order to keep things source compatible with what might be added to the standard library in the future.

This introduces overloads for the appropriate methods that take KeyPaths. A function called `get` is added that converts KeyPaths to their equivalent functions in order to reduce the boilerplate of inline closures. The spelling of `get` was borrowed from [swift-overture](https://github.com/pointfreeco/swift-overture/blob/e3e63876688ca8b6f327e5af7018f5e93e742367/Sources/Overture/KeyPath.swift#L9). I only needed `map`, `compactMap` and `filter` at the time, but I added the remaining methods from Sequence that seemed appropriate for completeness.